### PR TITLE
Database definition files, initial db client, docker-compose for local dev

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,14 +11,18 @@ Then from the root folder in this repo, run:
 
 ```
 docker-compose build
-docker-compose up
+docker-compose up -d
 ```
+
+To stream logs:
+`docker-compose logs -f`
+
+To stop streaming logs: `Control+C`
 
 To stop:
-
-```
+`
 docker-compose down
-```
+`
 
 To re-build, like when you change source code or similar, run `docker-compose build` again, and then
 `docker-compose up`.

--- a/README.md
+++ b/README.md
@@ -1,3 +1,30 @@
 # EthicalEating
 
 CS 361 Ethical Eating web app by Zero Rows Returned
+
+## running locally with docker-compose
+
+This is optional but I like testing locally with Docker, so you can do so too if you want. It's not required to develop, you can simply run a local SQL server and run the app with node app.js.
+
+If you'd like to run the app locally, you can download Docker Desktop: https://www.docker.com/products/docker-desktop
+Then from the root folder in this repo, run:
+
+```
+docker-compose build
+docker-compose up
+```
+
+To stop:
+
+```
+docker-compose down
+```
+
+To re-build, like when you change source code or similar, run `docker-compose build` again, and then
+`docker-compose up`.
+
+You can use the --force-recreate flag if changes don't seem to be sticking.
+
+`docker-compose up --force-recreate`
+
+You will be able to view the app locally at http://localhost:6377.

--- a/app.js
+++ b/app.js
@@ -20,6 +20,13 @@ app.set('view engine', 'handlebars');
 
 // routes TBD
 
+// Little database demo: visit http://localhost:6377/database-test and check logs.
+const { describeTables } = require("./database/client");
+app.get("/database-test", (_, res) => {
+  describeTables();
+  res.status(200).send("OK");
+})
+
 app.use((req,res) => {
     res.status(404);
     res.render('404');

--- a/database/client.js
+++ b/database/client.js
@@ -1,0 +1,51 @@
+// client.js sets up the database client for queries and provides an
+// "Am I connected?" sanity check with describeTables(). Could add
+// more in the way of connection management if needed.
+
+// Set-up adapted from docs here: https://www.npmjs.com/package/mysql2.
+
+const mysql = require("mysql2");
+
+// Create a connection pool.
+// Right now this is configured to work with Docker where the
+// database host is named "db". On flip this would change to
+// localhost, the user would change to your userid, and the
+// password to your flip database password.
+
+// TODO: it is generally a best practice to keep passwords and
+// secrets out of the repository. We can create a top-level
+// configuration file to hold the createPool instantiation
+// object. For now for development and testing, this is fine.
+const pool = mysql.createPool({
+  host: "db",
+  port: "3306",
+  user: "root",
+  password: "secret",
+  database: "EthicalEating",
+  waitForConnections: true,
+  connectionLimit: 10,
+  queueLimit: 0,
+});
+
+// describeTables runs DESCRIBE Users and DESCRIBE RecipeBooks so we can know
+// the DB connection is working and the initialization script was successful.
+
+const describeTables = () => {
+  // Describe the two tables we should be creating so far in database-definitions.sql.
+  pool.query("DESCRIBE Users;", function (err, results, fields) {
+    if (err) {
+      console.log(`error: ${err}`); // any error
+    }
+    console.log(results); // results contains rows returned by server
+    // console.log(fields); // fields contains extra meta data about results, if available
+  });
+  pool.query("DESCRIBE RecipeBooks;", function (err, results, fields) {
+    if (err) {
+      console.log(`error: ${err}`); // any error
+    }
+    console.log(results); // results contains rows returned by server
+    // console.log(fields); // fields contains extra meta data about results, if available
+  });
+};
+
+module.exports = { describeTables };

--- a/database/database-definitions.sql
+++ b/database/database-definitions.sql
@@ -1,0 +1,48 @@
+-- CS361 OSU Fall 2020 Zero Rows Returned
+-- The queries in this file initialize the Database Tables for the project.
+-- This file will be run on database initialization to set up the database.
+-- Right now it does not delete any data, but it could TRUNCATE TABLE or
+-- even drop & recreate the entire database if you want a fresh start every time.
+
+-- Using the CHARACTER SET=utf8mb4; flag allows for Unicode characters (non-ASCII), including emoji :)
+
+-- TODO: Tables To be defined
+-- Recipes
+-- Ingredients
+-- RecipeIngredients
+
+CREATE DATABASE IF NOT EXISTS EthicalEating;
+USE EthicalEating;
+
+CREATE TABLE IF NOT EXISTS Users(
+  id INT NOT NULL AUTO_INCREMENT PRIMARY KEY,
+  username VARCHAR(99) NOT NULL,
+  password VARCHAR(99) NOT NULL,
+  CONSTRAINT UNIQUE(username)
+) CHARACTER SET=utf8mb4;
+
+CREATE TABLE IF NOT EXISTS RecipeBooks(
+  id INT NOT NULL AUTO_INCREMENT PRIMARY KEY,
+  owner_id INT NOT NULL,
+  FOREIGN KEY (owner_id) REFERENCES Users (id) ON DELETE CASCADE ON UPDATE CASCADE
+) CHARACTER SET=utf8mb4;
+
+-- TODO: commented out for now because creation fails since Recipes doesn't exist yet :)
+-- See TABLES TO BE DEFINED at top.
+-- CREATE TABLE IF NOT EXISTS RecipeBookRecipes(
+--   id INT NOT NULL AUTO_INCREMENT PRIMARY KEY,
+--   recipe_id INT NOT NULL,
+--   recipebook_id INT NOT NULL,
+--   FOREIGN KEY (recipe_id) REFERENCES Recipes (id)
+--   FOREIGN KEY (recipebook_id) REFERENCES RecipeBooks (id)
+-- ) CHARACTER SET=utf8mb4;
+
+-- TODO: commented out for now because creation fails since Ingredients doesn't exist yet :)
+-- See TABLES TO BE DEFINED at top.
+-- CREATE TABLE IF NOT EXISTS IngredientReplacements(
+--     id INT NOT NULL AUTO_INCREMENT PRIMARY KEY,
+--     ingredient_id_replaces INT NOT NULL,
+--     ingredient_id_replacement INT NOT NULL,
+--     FOREIGN KEY (ingredient_id_replaces) REFERENCES Ingredients (id)
+--     FOREIGN KEY (ingredient_id_replacement) REFERENCES Ingredients (id)
+-- ) CHARACTER SET=utf8mb4;

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,21 @@
+version: "3.8"
+services:
+  db:
+    image: mariadb
+    environment:
+      MYSQL_ROOT_PASSWORD: secret
+    # https://stackoverflow.com/a/43331395 init database by running database-definitions.sql file
+    command: --init-file /data/application/init.sql
+    volumes:
+      - ./database/database-definitions.sql:/data/application/init.sql
+    ports:
+      - "3306"
+  webapp:
+    build:
+      context: .
+      dockerfile: webapp_dockerfile
+    command: "npm start"
+    depends_on:
+      - "db"
+    ports:
+      - "6377:6377"

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "description": "Web app to help users make more ethical choices in terms of meals and ingredients",
   "main": "app.js",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "echo \"Error: no test specified\" && exit 1",
+    "start": "node app.js"
   },
   "repository": {
     "type": "git",

--- a/webapp_dockerfile
+++ b/webapp_dockerfile
@@ -1,0 +1,13 @@
+# FROM node:6.10.2-alpine
+# The above line is what's running on flip. It doesn't work with
+# express-handlebars due to use of async.
+
+# Temporarily using a later version of Node so we can use async and such here.
+# But this must be resolved soon.
+
+FROM node:12.19.0-alpine
+WORKDIR /app
+COPY package.json /app
+RUN npm install
+COPY . /app
+EXPOSE 6377


### PR DESCRIPTION
This PR:
* adds a `database/database-definitions.sql` database definitions file to create tables
* simple client code using the mysql2 npm library
* a Dockerfile to build the webapp
* a docker-compose file to run the webapp alongside the db (including running the database-definitions.sql on startup)
* instructions in the README, for the _totally optional_ use of these Docker tools for running everything locally