### PR TITLE
Merge DB schemas, add backend-database "bridge layer" / API

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,10 @@ docker-compose build
 docker-compose up -d
 ```
 
+The app has been configured with [nodemon](https://www.npmjs.com/package/nodemon) to hot-reload the app container whenever the source code changes. This way, you don't have to bring the container down and back up again when you make a change in the source code in order to see the behavior reflected. This makes development faster.
+
+If you don't want this behavior, simply change the `command: "npm run dev"` line in docker-compose.yml to `command: "npm start"` and hot-reloading will no longer occur.
+
 To stream logs:
 `docker-compose logs -f`
 
@@ -32,3 +36,7 @@ You can use the --force-recreate flag if changes don't seem to be sticking.
 `docker-compose up --force-recreate`
 
 You will be able to view the app locally at http://localhost:6377.
+
+## viewing the mysql database with mysql workbench
+
+It can be useful for debugging to see what is in the database using [mysql workbench](https://www.mysql.com/products/workbench/), a free tool. If you would like to use the app with mysql workbench, first download the software. Then, make one small change to the docker-compose file to the db: ports: section, changing `"3306"` to `"127.0.0.1:3306:3306"` to expose the database on port 3306 on your localhost.

--- a/app.js
+++ b/app.js
@@ -18,6 +18,18 @@ app.engine(
 
 app.set('view engine', 'handlebars');
 
+// Demo of how to create and log in a user...
+const { Users } = require("./database");
+app.get("/demo", (_, res) => {
+  Users.createUserWithUsernameAndPassword({"username": "foo", "password": "bar"}, (error, user) => {
+    console.log("user creation error:", error, "newly created user:", user);
+      Users.logInWithUsernameAndPassword({"username": "foo", "password": "bar"}, (error, user) => {
+        console.log("login error:", error, "logged in user:", user);
+      });
+  });
+  res.status(200).send("demo ok");
+})
+
 // routes TBD
 app.get("/login", (req, res) => {
   res.render('login');
@@ -25,13 +37,6 @@ app.get("/login", (req, res) => {
 
 app.get("/", (req, res) => {
   res.render('index');
-})
-
-// Little database demo: visit http://localhost:6377/database-test and check logs.
-const { describeTables } = require("./database/client");
-app.get("/database-test", (_, res) => {
-  describeTables();
-  res.status(200).send("OK");
 })
 
 app.use((req,res) => {

--- a/database/IngredientReplacements.js
+++ b/database/IngredientReplacements.js
@@ -1,0 +1,167 @@
+const { toJSON, buildResponseList, buildCreateResponse } = require("./utils");
+
+/**
+IngredientReplacement is a recommended replacement of one Ingredient for another Ingredient
+in the system. We suggest an IngredientReplacement when a more ethical Ingredients exists
+for a given Ingredient. An IngredientReplacement may not replace an Ingredient with itself.
+*/
+
+// IngredientReplacement class. A database query for IngredientReplacements
+// returns instances of the IngredientReplacement class.
+class IngredientReplacement {
+  constructor({
+    id,
+    replacementReason,
+    ingredientIDReplaces,
+    ingredientIDReplacement,
+  } = {}) {
+    this.id = id;
+    this.replacementReason = replacementReason;
+    this.ingredientIDReplaces = ingredientIDReplaces;
+    this.ingredientIDReplacement = ingredientIDReplacement;
+  }
+
+  // fromDatabaseRow returns an instance of the class, populating data from database row @dbRow.
+  static fromDatabaseRow(dbRow) {
+    return new IngredientReplacement({
+      id: dbRow.id,
+      replacementReason: dbRow.replacement_reason,
+      ingredientIDReplaces: dbRow.ingredient_id_replaces,
+      ingredientIDReplacement: dbRow.ingredient_id_replacement,
+    });
+  }
+
+  // getID returns the ID of the IngredientReplacement.
+  getID() {
+    return this.id;
+  }
+
+  // toJSON returns a JSON representation of the entity with private ("_"-prefixed) fields removed.
+  toJSON() {
+    return toJSON(this);
+  }
+}
+
+// IngredientReplacements. Defines queries for IngredientReplacements. Instantiated with
+// @database, a reference to the mysql connection pool to be used for queries.
+const IngredientReplacements = (database) => {
+  // Define any Error messages or Data Validator functions for the module.
+  const Errors = {};
+  const Validators = {};
+
+  // ======> BEGIN QUERIES <======
+
+  // We attach all these queries to the ingredientReplacement object which gets returned and exported from the module.
+  const ingredientReplacement = {};
+
+  /**
+    createIngredientReplacement creates an IngredientReplacement replacing Ingredient with
+    ID @ingredientIDReplaces with Ingredient with ID @ingredientIDReplacement for ethical
+    reason @replacementReason.
+
+    Creation fails if either of the two Ingredients do not exist or if the Ingredient IDs are
+    the same (since an Ingredient cannot replace itself).
+    => Receives:
+      + ingredientIDReplaces: ID of the Ingredient A to replace.
+      + ingredientIDReplacement: ID of the Ingredient to replace Ingredient A with.
+      + replacementReason: Description of the reason why we are making the replacement.
+      + callback: function(error, data)
+    => Returns: by calling @callback with:
+      + (null, Instance of created IngredientReplacement object) on creation success.
+      + (Error, null) if an error occurs.
+    => Code Example:
+      // Create an IngredientReplacement, replacing Ingredient with ID = 1 with Ingredient with
+      // ID = 2 for reason @replacementReason.
+      IngredientReplacements.createIngredientReplacement({
+        ingredientIDReplaces: 1,
+        ingredientIDReplacement: 2,
+        replacementReason: "This ingredient requires less water to produce.",
+      }, (err, newIngredientReplacement) => {
+        if (err) {
+          console.log("Failed to create IngredientReplacement:", err);
+          return; // bail out of the handler here, newIngredientReplacement undefined
+        }
+        console.log("Created newIngredientReplacement:", newIngredientReplacement, "json: ", newIngredientReplacement.toJSON());
+      });
+    */
+  ingredientReplacement.createIngredientReplacement = (
+    { ingredientIDReplaces, ingredientIDReplacement, replacementReason },
+    callback
+  ) => {
+    if (ingredientIDReplaces === ingredientIDReplacement) {
+      callback(
+        new Error(
+          "You cannot create an IngredientReplacement that replaces an Ingredient with itself."
+        ),
+        null
+      );
+      return;
+    }
+    database.execute(
+      `
+      INSERT INTO IngredientReplacements(ingredient_id_replaces, ingredient_id_replacement, replacement_reason)
+      VALUES (?, ?, ?)
+      `,
+      [ingredientIDReplaces, ingredientIDReplacement, replacementReason],
+      (err, rows) =>
+        buildCreateResponse(
+          err,
+          rows,
+          { ingredientIDReplaces, ingredientIDReplacement, replacementReason },
+          IngredientReplacement,
+          callback
+        )
+    );
+  };
+
+  /**
+    getReplacementsForIngredient returns a list of IngredientReplacements for Ingredient
+    with ID @ingredientIDToReplace. The list may be empty if no replacements exist or
+    if the Ingredient with @ingredientIDToReplace does not exist.
+    => Receives:
+      + ingredientIDToReplace: ID of the Ingredient to find IngredientReplacements for.
+      + callback: function(error, data)
+    => Returns: by calling @callback with:
+      + (null, []IngredientReplacement objects) on query success. List may be empty.
+      + (Error, null) if an error occurs.
+    => Notes:
+      + TODO: make a query that returns the IngredientReplacements as Ingredient objects directly
+      by joining to Ingredients.
+    => Code Example:
+      // Find IngredientReplacements for Ingredient with @ingredientID = 1.
+      IngredientReplacements.getReplacementsForIngredient(
+        { ingredientID: 1 },
+        (err, listOfIngredientReplacements) => {
+          if (err) {
+            console.log("Failed to get IngredientReplacements:", err);
+            return; // bail out of the handler here, listOfIngredientReplacements undefined
+          }
+          console.log("Fetched listOfIngredientReplacements:", listOfIngredientReplacements);
+          console.log("List as JSON objects",
+            listOfIngredientReplacements.map((ingredientReplacement) =>
+              ingredientReplacement.toJSON()
+            )
+          );
+        }
+      );
+  */
+  ingredientReplacement.getReplacementsForIngredient = (
+    { ingredientID },
+    callback
+  ) => {
+    database.execute(
+      "SELECT * FROM IngredientReplacements WHERE ingredient_id_replaces = ?",
+      [ingredientID],
+      (err, rows) => {
+        if (err) {
+          callback(err, null);
+        }
+        buildResponseList(err, rows, IngredientReplacement, callback);
+      }
+    );
+  };
+
+  return { ...ingredientReplacement, Errors, Validators };
+};
+
+module.exports = { IngredientReplacements, IngredientReplacement };

--- a/database/Ingredients.js
+++ b/database/Ingredients.js
@@ -1,0 +1,138 @@
+const { buildCreateResponse, buildResponse, toJSON } = require("./utils");
+
+/**
+Ingredient is an Ingredient in the system. A Recipe consists of zero or more Ingredients.
+An Ingredient is mapped to a Recipe by a RecipeIngredient. The same Ingredient may appear
+in multiple Recipes.
+*/
+
+// Ingredient class. A database query for Ingredients returns instances of the Ingredient class.
+class Ingredient {
+  constructor({ id, name, description } = {}) {
+    this.id = id;
+    this.name = name;
+    this.description = description;
+  }
+
+  // fromDatabaseRow returns an instance of the class, populating data from database row @dbRow.
+  static fromDatabaseRow(dbRow) {
+    return new Ingredient({
+      id: dbRow.id,
+      name: dbRow.name,
+      description: dbRow.description,
+    });
+  }
+
+  // getID returns the ID of the Ingredient.
+  getID() {
+    return this.id;
+  }
+
+  // toJSON returns a JSON representation of the entity with private ("_"-prefixed) fields removed.
+  toJSON() {
+    return toJSON(this);
+  }
+}
+
+// Ingredients defines queries for Ingredients. Instantiated with @database,
+// a reference to the mysql connection pool to be used for queries.
+const Ingredients = (database) => {
+  // Define any Error messages or data Validator functions for the module.
+  const Errors = {
+    notFound: "That ingredient does not exist.",
+  };
+  const Validators = {};
+
+  // ======> BEGIN QUERIES <======
+
+  // We attach all these queries to the ingredients object which gets returned and exported from the module.
+  const ingredients = {};
+
+  /**
+    createIngredient creates a new Ingredient with name @name and description @description.
+    => Receives:
+      + name: Name of the Ingredient.
+      + description: Description of the Ingredient.
+      + callback: function(error, data)
+    => Returns: by calling @callback with:
+      + (null, Ingredient) with the Ingredient object that was created.
+      + (Error, null) if an error occurs.
+    => Code Example:
+      // Create an Ingredient with @name "foo" and @description "desc".
+      Ingredients.createIngredient({ name: "foo", description: "desc" }, (err, newIngredientObject) => {
+        if (err) {
+          console.log("Failed to create the ingredient. Error:", err);
+          return; // bail out of the handler here, newIngredientObject undefined
+        }
+        // Created the ingredient successfully.
+        console.log("newIngredientObject:", newIngredientObject, "json:", newIngredientObject.toJSON());
+    });
+  */
+  ingredients.createIngredient = ({ name, description }, callback) => {
+    database.execute(
+      "INSERT INTO Ingredients(name, description) VALUES(?, ?)",
+      [name, description],
+      (err, rows) => {
+        console.log(err, rows);
+        if (err) {
+          callback(err, null);
+          return;
+        }
+        buildCreateResponse(
+          err,
+          rows,
+          { name, description },
+          Ingredient,
+          callback
+        );
+      }
+    );
+  };
+
+  /**
+    getIngredient fetches the Ingredient with ID @ingredientID if it exists.
+    => Receives:
+      + ingredientID: ID of the Ingredient to fetch.
+      + callback: function(error, data)
+    => Returns: by calling @callback with:
+      + (null, Ingredient) with the Ingredient object that was fetched.
+      + (Ingrdients.Errors.notFound, null) if the Ingredient could not be found.
+      + (Error, null) if another error occurs.
+    => Code Example:
+      // Fetch an Ingredient with ID @ingredientID = 2.
+      Ingredients.getIngredient({ ingredientID: 2 }, (err, ingredientObject) => {
+        if (err) {
+          if (err === Ingredients.Errors.notFound) {
+            console.log("Could not find the ingredient.");
+            return; // bail out of the handler here, ingredientObject undefined
+          }
+          // Another error occurred.
+          console.log("An error occurred with the query. Error:", err);
+          return; // bail out of the handler here, ingredientObject undefined
+        }
+        // Fetched the Ingredient successfully.
+        console.log("ingredientObject:", ingredientObject, "json:", ingredientObject.toJSON());
+      });
+  */
+  ingredients.getIngredient = ({ ingredientID }, callback) => {
+    database.execute(
+      "SELECT * FROM Ingredients WHERE id = ?",
+      [ingredientID],
+      (err, rows) => {
+        console.log(err, rows);
+        if (err) {
+          callback(err, null);
+          return;
+        }
+        if (!rows || rows.length !== 1) {
+          callback(Errors.notFound, null);
+        }
+        buildResponse(err, rows, Ingredient, callback);
+      }
+    );
+  };
+
+  return { ...ingredients, Errors, Validators };
+};
+
+module.exports = { Ingredients, Ingredient };

--- a/database/RecipeBookRecipes.js
+++ b/database/RecipeBookRecipes.js
@@ -1,0 +1,202 @@
+const { buildResponseList, toJSON } = require("./utils");
+const { Recipe } = require("./Recipes");
+const { Ingredient } = require("./Ingredients");
+
+/*
+RecipeBookRecipe maps a Recipe in a User's RecipeBook to a Recipe object.
+There is exactly 0 or 1 RecipeBookRecipe rows for a given Recipe and RecipeBook.
+That is, a RecipeBook may not contain multiple copies of the same Recipe.
+*/
+
+// RecipeBookRecipe class. A database query for RecipeBookRecipes returns instances of this RecipeBookRecipe class.
+class RecipeBookRecipe {
+  constructor({ id, recipeID, recipeBookID } = {}) {
+    this.id = id;
+    this.recipeID = recipeID;
+    this.recipeBookID = recipeBookID;
+  }
+
+  // fromDatabaseRow returns an instance of the class, populating data from database row @dbRow.
+  static fromDatabaseRow(dbRow) {
+    return new RecipeBookRecipes({
+      id: dbRow.id,
+      recipeID: dbRow.recipe_id,
+      recipeBookID: dbRow.recipebook_id,
+    });
+  }
+
+  // getID returns the ID of the RecipeBookRecipe.
+  getID() {
+    return this.id;
+  }
+
+  // toJSON returns a JSON representation of the entity with private ("_"-prefixed) fields removed.
+  toJSON() {
+    return toJSON(this);
+  }
+}
+
+// RecipeBookRecipes defines queries for RecipeBookRecipes. Instantiated with
+// @database, a reference to the mysql connection pool to be used for queries.
+const RecipeBookRecipes = (database) => {
+  // Define any Error messages or Data Validator functions for the module.
+  const Errors = {};
+  const Validators = {};
+
+  // ======> BEGIN QUERIES <======
+
+  // We attach all these queries to the recipeBookRecipes object which gets
+  // returned and exported from the module.
+  const recipeBookRecipes = {};
+
+  /**
+    getAllRecipes fetches all RecipeBookRecipes from the RecipeBook with ID @recipeBookID
+    and returns a list of Recipe objects.
+    => Receives:
+      + recipeBookID: ID of RecipeBook from which to fetch Recipes.
+      + callback function(error, data)
+    => Returns: by calling @callback with:
+      + (null, []Recipe) a list of Recipe objects on query success. List may be empty.
+      + (Error, null) if an error occurs.
+    => Code Example:
+      // Get a list of every Recipe object in RecipeBook with ID @recipeBookID = 1.
+      RecipeBookRecipes.getAllRecipes({recipeBookID: 1}, (err, listOfRecipeObjects) => {
+        if (err) { // Couldn't fetch the recipes.
+          console.log(err);
+          return; // bail out of the handler here, listOfRecipeObjects undefined
+        }
+        // Fetched list of Recipes in RecipeBook.
+        console.log("listOfRecipeObjects:", listOfRecipeObjects);
+      });
+  */
+  recipeBookRecipes.getAllRecipes = ({ recipeBookID }, callback) => {
+    database.execute(
+      `
+      SELECT * FROM RecipeBookRecipes rbr
+      INNER JOIN Recipes r
+      ON rbr.recipe_id = r.id
+      WHERE rbr.recipebook_id = ?
+      `,
+      [recipeBookID],
+      (err, rows) => {
+        if (err) {
+          callback(err, null);
+          return;
+        }
+        buildResponseList(err, rows, Recipe, callback);
+      }
+    );
+  };
+
+  /**
+    getAllRecipesWithIngredients fetches all RecipeBookRecipes from the RecipeBook with ID @recipeBookID
+    and returns list of objects containing Recipes and a list of each Recipe's Ingredient objects.
+    => Receives:
+      + recipeBookID: ID of RecipeBook from which to fetch Recipes.
+      + callback function(error, data)
+    => Returns: by calling @callback with:
+      + (null, []{recipe:Recipe, ingredients: []Ingredient})
+        => Returns a list (possibly empty) of objects with keys "recipe" and
+        "ingredients". "recipe" maps to the Recipe object and "ingredients" maps to a list
+        of Ingredient objects constituting that Recipe's Ingredients. List may be empty.
+      + (Error, null) if an error occurs.
+    => Code Example:
+      // Get a list of every Recipe object in RecipeBook with ID @recipeBookID = 1.
+      RecipeBookRecipes.getAllRecipes({recipeBookID: 1}, (err, listOfRecipeAndIngredientObjects) => {
+        if (err) {
+          // Couldn't fetch the recipes.
+          console.log(err);
+          return; // bail out of the handler here, listOfRecipeAndIngredientObjects undefined
+        }
+        // Fetched list of Recipes in RecipeBook.
+        console.log("listOfRecipeAndIngredientObjects:", listOfRecipeAndIngredientObjects);
+      });
+    => Sample Returned Data:
+        [
+          {
+          "recipe": {
+            "id": 1,
+            "name": "Recipe 1",
+            "isPublic": 1
+          },
+          "ingredients": [
+            {
+              "id": 1,
+              "name": "ingredient 1",
+              "description": "description 1"
+            },
+            {
+              "id": 2,
+              "name": "ingredient 2",
+              "description": "description 2"
+            }
+          ]
+      },
+      {
+        "recipe": {
+          "id": 2,
+          "name": "Recipe 2",
+          "isPublic": 1
+        },
+        "ingredients": [
+          {
+            "id": 2,
+            "name": "ingredient 2",
+            "description": "description 2"
+          }
+        ]
+      }
+    ]
+  */
+  recipeBookRecipes.getAllRecipesWithIngredients = (
+    { recipeBookID },
+    callback
+  ) => {
+    // TODO: ensure when we deploy that JSON_ARRAYAGG function is present
+    // in the database we are using. If not, break up query into multiple.
+    database.execute(
+      `
+      SELECT *, CONCAT(CONCAT('[', JSON_ARRAYAGG(data.ingredients)), ']') as ingredients FROM
+      (
+        SELECT r.id, r.name, r.is_public,
+          (
+            SELECT
+            JSON_OBJECT("id", i.id, "name", i.name, "description", i.description)
+            FROM Ingredients
+            WHERE id = i.id
+          ) as "ingredients"
+        FROM RecipeBookRecipes rbr
+        INNER JOIN Recipes r ON rbr.recipe_id = r.id
+        INNER JOIN RecipeIngredients ri ON ri.recipe_id = r.id
+        INNER JOIN Ingredients i ON ri.ingredient_id = i.id
+        WHERE rbr.recipebook_id = ?
+      ) data
+      GROUP BY data.id
+      `,
+      [recipeBookID],
+      (err, rows) => {
+        if (err) {
+          callback(err, null);
+          return;
+        }
+        callback(
+          err,
+          rows.map((recipeWithIngredients) => {
+            const parsedIngredients = JSON.parse(
+              recipeWithIngredients.ingredients
+            );
+            const recipe = Recipe.fromDatabaseRow(recipeWithIngredients);
+            const ingredients = parsedIngredients.map((ingredient) =>
+              Ingredient.fromDatabaseRow(ingredient).toJSON()
+            );
+            return { recipe, ingredients };
+          })
+        );
+      }
+    );
+  };
+
+  return { recipeBookRecipes, Errors, Validators };
+};
+
+module.exports = { RecipeBookRecipes, RecipeBookRecipe };

--- a/database/RecipeBooks.js
+++ b/database/RecipeBooks.js
@@ -1,0 +1,203 @@
+const { buildCreateResponse, toJSON, buildResponseList } = require("./utils");
+const { Recipe } = require("./Recipes");
+
+/*
+RecipeBook represents a User's RecipeBook in the system.
+RecipeBooks have an id and an ownerID. ownerID is a foreign key to the userID
+to which the RecipeBook belongs. Users may have exactly 0 or 1 RecipeBook.
+*/
+
+// RecipeBook class. A database query for RecipeBooks returns instances of the RecipeBook class.
+class RecipeBook {
+  constructor({ id, ownerID } = {}) {
+    this.id = id;
+    this.ownerID = ownerID;
+  }
+
+  // fromDatabaseRow returns an instance of the class, populating data from database row @dbRow.
+  static fromDatabaseRow(dbRow) {
+    return new RecipeBook({
+      id: dbRow.id,
+      ownerID: dbRow.owner_id,
+    });
+  }
+
+  // getID returns the ID of the RecipeBook.
+  getID() {
+    return this.id;
+  }
+
+  // toJSON returns a JSON representation of the entity with private ("_"-prefixed) fields removed.
+  toJSON() {
+    return toJSON(this);
+  }
+}
+
+// RecipeBooks defines queries for RecipeBooks. Instantiated with @database,
+// a reference to the mysql connection pool to be used for queries.
+const RecipeBooks = (database) => {
+  // Define any Error messages or Data Validator functions for the module.
+  const Errors = {
+    notFound: "No RecipeBook with that ID exists.",
+    recipeBookAlreadyExists: "RecipeBook already exists for user.",
+  };
+
+  const Validators = {};
+
+  // ======> BEGIN QUERIES <======
+
+  // We attach all these queries to the recipeBook object which gets returned and exported from the module.
+  const recipeBook = {};
+
+  /**
+    addRecipeByIDToRecipeBookWithID adds the Recipe with ID @recipeID to the RecipeBook with ID @recipeBookID.
+    Fails if either Recipe with ID does not exist, RecipeBook with ID does not exist, or Recipe with ID
+    already exists in the RecipeBook.
+    => Receives:
+      + recipeID: ID of Recipe to add to RecipeBook with ID recipeBookID.
+      + recipeBookID: ID of RecipeBook into which to add a new Recipe.
+      + callback function(error, data)
+    => Returns: by calling @callback with:
+      + (null, insertionInfo) on addition success.
+      + (Error, null) if an error occurs.
+    => Code Example:
+      // Add Recipe with ID @recipeID = 2 to RecipeBook with ID @recipeBookId = 1.
+      RecipeBooks.addRecipeByIDToRecipeBookWithID({recipeID: 2, recipeBookID: 1}, (err, insertionInfo) => {
+        if (err) { // addition failed
+          return;  // bail out of the handler here, insertionInfo undefined
+        }
+        // Addition successful. @insertionInfo contains info about the insert if needed.
+      });
+  */
+  recipeBook.addRecipeByIDToRecipeBookWithID = (
+    { recipeID, recipeBookID },
+    callback
+  ) => {
+    database.execute(
+      "INSERT INTO RecipeBookRecipes(recipe_id, recipebook_id) VALUES(?, ?)",
+      [recipeID, recipeBookID],
+      (err, data) => callback(err, data)
+    );
+  };
+
+  /**
+    getRecipesForRecipeBookID returns a list of Recipe objects for all the Recipes in
+    the RecipeBook with ID = @recipeBookID. Returns both public and private Recipes.
+    => Receives:
+      + recipeBookID: ID of RecipeBook from which to fetch list of Recipes.
+      + callback: function(error, data)
+    => Returns by calling @callback with:
+      + (null, []Recipe) array of Recipe objects on query success. Array may be empty.
+      + (Error, null) if an error occurs.
+    => Code Example:
+      // Get a list of every Recipe object for RecipeBook with ID @recipeBookID = 1.
+      RecipeBooks.getRecipesForRecipeBookID(
+        { recipeBookID: 1 },
+        (err, listOfRecipeObjects) => {
+          if (err) {
+            if (err === RecipeBooks.Errors.notFound) {
+              // No RecipeBook Recipes found.
+              console.log(err);
+              return; // bail out of the handler here, listOfRecipeObjects undefined
+            }
+            console.log("Some other database error:", err);
+            return; // bail out of the handler here, listOfRecipeObjects undefined
+          }
+          // Fetched list of Recipes successfully.
+          console.log("data", listOfRecipeObjects);
+        }
+      );
+  */
+  recipeBook.getRecipesForRecipeBookID = ({ recipeBookID }, callback) => {
+    database.execute(
+      `
+      SELECT r.* FROM RecipeBookRecipes rbr
+      INNER JOIN Recipes r ON r.id = rbr.recipe_id
+      WHERE recipebook_id = ?
+      `,
+      [recipeBookID],
+      (err, rows) => {
+        if (err) {
+          callback(err, null);
+          return;
+        }
+        buildResponseList(err, rows, Recipe, callback);
+      }
+    );
+  };
+
+  /**
+    createRecipeBookForOwningUserID creates a RecipeBook for User with ID = @userID.
+    The addition will fail if a User with ID = @userID does not exist, or if the
+    User with @userID already has a RecipeBook. On RecipeBook creation, the User's
+    recipebook_id field is updated with the ID of the newly created RecipeBook.
+    => Receives:
+      + userID: userID for which to create a RecipeBook.
+      + callback: function(error, data)
+    => Returns: by calling @callback with:
+      + (null, RecipeBook) instance of the created RecipeBook on creation success.
+      + (RecipeBooks.Errors.recipeBookAlreadyExists, null) if the RecipeBook already exists for the User.
+      + (Error, null) if another error occurs.
+    => Code Example:
+      // Create a RecipeBook for User with ID @userID = 1.
+      RecipeBooks.createRecipeBookForOwningUserID(
+        { userID: 1 },
+        (err, recipeBookObject) => {
+          if (err) {
+            if (err === RecipeBooks.Errors.recipeBookAlreadyExists) {
+              // The RecipeBook already exists for the user.
+              console.log(err); // bail out of the handler here, recipeBookObject undefined
+              return;
+            }
+            console.log("Some other database error:", err);
+            return; // bail out of the handler here, recipeBookObject undefined
+          }
+          // RecipeBook was created.
+          console.log("recipeBookObject:", recipeBookObject, "json:", recipeBookObject.toJSON());
+        }
+      );
+    */
+  recipeBook.createRecipeBookForOwningUserID = ({ userID }, callback) => {
+    database.execute(
+      "INSERT INTO RecipeBooks(owner_id) VALUES(?)",
+      [userID],
+      (err, insertResult) => {
+        if (err) {
+          if (err.code === "ER_DUP_ENTRY") {
+            callback(Errors.recipeBookAlreadyExists, null);
+            return;
+          }
+          // Some other error occurred. No data.
+          callback(err, null);
+          return;
+        }
+
+        // Now update the User's recipebook_id with the new RecipeBook ID.
+        const newRecipeBookID = insertResult.insertId;
+        database.execute(
+          "UPDATE Users SET recipebook_id = ? WHERE id = ?",
+          [newRecipeBookID, userID],
+          (err, rows) => {
+            if (err) {
+              // Some other error occurred. No data.
+              callback(err, null);
+              return;
+            }
+            // Query successful. Build response for callback.
+            buildCreateResponse(
+              err,
+              rows,
+              { id: newRecipeBookID, ownerID: userID },
+              RecipeBook,
+              callback
+            );
+          }
+        );
+      }
+    );
+  };
+
+  return { ...recipeBook, Errors, Validators };
+};
+
+module.exports = { RecipeBooks, RecipeBook };

--- a/database/Recipes.js
+++ b/database/Recipes.js
@@ -1,0 +1,194 @@
+const { Ingredient } = require("./Ingredients");
+const { buildCreateResponse, toJSON, buildResponseList } = require("./utils");
+
+/*
+Recipe represents a Recipe in the system. A Recipe has zero or more Ingredients.
+A Recipe can have a public or private status. A Recipe is owned by a User and
+can be placed into a RecipeBook.
+*/
+
+// Recipe class. A database query for Recipes returns instances of the Recipe class.
+class Recipe {
+  constructor({ id, name, isPublic } = {}) {
+    this.id = id;
+    this.name = name;
+    this.isPublic = isPublic;
+  }
+
+  // fromDatabaseRow returns an instance of the class, populating data from database row @dbRow.
+  static fromDatabaseRow(dbRow) {
+    return new Recipe({
+      id: dbRow.id,
+      name: dbRow.name,
+      isPublic: dbRow.is_public === 1 ? true : false,
+    });
+  }
+
+  // getID returns the ID of the Recipe.
+  getID() {
+    return this.id;
+  }
+
+  // toJSON returns a JSON representation of the entity with private ("_"-prefixed) fields removed.
+  toJSON() {
+    return toJSON(this);
+  }
+}
+
+// Recipes defines queries for Recipes. Instantiated with @database,
+// a reference to the mysql connection pool to be used for queries.
+const Recipes = (database) => {
+  // Define any Error messages or Data Validator functions for the module.
+  const Errors = {
+    recipeBookAlreadyExists: "RecipeBook already exists for user.",
+  };
+  const Validators = {};
+
+  // ======> BEGIN QUERIES <======
+
+  // We attach all these queries to the recipes object which gets returned and exported from the module.
+  const recipes = {};
+
+  /*
+    createRecipe creates the Recipe with @name and @isPublic status.
+    => Receives:
+      + name: Name of the Recipe.
+      + isPublic: Whether the Recipe is publicly visible.
+      + callback: function(error, data)
+    => Returns: by calling @callback with:
+      + (null, Recipe) with the Recipe object that was created.
+      + (Error, null) if an error occurs.
+    => Code Example:
+      // Create a Recipe with @name "foo" that is public since @isPublic = true.
+      Recipes.createRecipe({ name: "foo", isPublic: true }, (err, newRecipeObject) => {
+        if (err) {
+          console.log("Failed to create the recipe. Error:", err);
+          return; // bail out of the handler here, newRecipeObject undefined
+        }
+        // Created the recipe successfully.
+        console.log("newRecipeObject:", newRecipeObject, "json:", newRecipeObject.toJSON());
+      });
+  */
+  recipes.createRecipe = ({ name, isPublic }, callback) => {
+    database.execute(
+      "INSERT INTO Recipes(name, is_public) VALUES(?, ?)",
+      [name, isPublic],
+      (err, rows) => {
+        if (err) {
+          callback(err, null);
+          return;
+        }
+        buildCreateResponse(err, rows, { name, isPublic }, Recipe, callback);
+      }
+    );
+  };
+
+  /**
+    addIngredientIDToRecipeID adds Ingredient with ID @ingredientID to Recipe with ID @recipeID.
+    => Receives:
+      + ingredientID: ID of the Ingredient to add to Recipe.
+      + recipeID: ID of the Recipe to which to add the Ingredient.
+      + callback: function(error, data)
+    => Returns: by calling @callback with:
+      + (null, null) returns nothing on success
+      + (Error, null) if an error occurs.
+    => Code Example:
+      // Create a Recipe with @name "foo" that is public since @isPublic = true.
+      Recipes.createRecipe({ name: "foo", isPublic: true }, (err, newRecipeObject) => {
+        if (err) {
+          console.log("Failed to create the recipe. Error:", err);
+          return; // bail out of the handler here, newRecipeObject undefined
+        }
+        // Created the recipe successfully.
+        console.log("newRecipeObject:", newRecipeObject, "json:", newRecipeObject.toJSON());
+      });
+  */
+  recipes.addIngredientIDToRecipeID = (
+    { ingredientID, recipeID },
+    callback
+  ) => {
+    database.execute(
+      "INSERT INTO RecipeIngredients(ingredient_id, recipe_id) VALUES (?, ?)",
+      [ingredientID, recipeID],
+      (err) => {
+        if (err) {
+          callback(err, null);
+          return;
+        }
+        callback(null, null);
+      }
+    );
+  };
+
+  /**
+    getIngredients gets a list of Ingredient objects for Recipe with ID @recipeID
+    => Receives:
+      + recipeID: ID of the Recipe for which to fetch the list of Ingredients.
+      + callback: function(error, data)
+    => Returns: by calling @callback with:
+      + (null, []Ingredients) a list of Ingredient objects in the Recipe.
+      + (Error, null) if an error occurs.
+    => Code Example:
+      // Get list of Ingredients for Recipe with ID @recipeID.
+      Recipes.getIngredients({ recipeID: 1 }, (err, listOfIngredients) => {
+        if (err) {
+            console.log("Failed to fetch recipe ingredients:", err);
+            return; // bail out of the handler here, listOfIngredients undefined
+        }
+        // Got the Ingredients list.
+        console.log("listOfIngredients:", listOfIngredients);
+        console.log("listOfIngredients as json", listOfIngredients.map(ingredient => ingredient.toJSON()));
+      });
+  */
+  recipes.getIngredients = ({ recipeID }, callback) => {
+    database.execute(
+      `
+      SELECT * FROM Ingredients i
+      INNER JOIN RecipeIngredients ri
+      ON i.id = ri.ingredient_id
+      WHERE ri.recipe_id = ?
+      `,
+      [recipeID],
+      (err, rows) => {
+        if (err) {
+          callback(err, null);
+          return;
+        }
+        buildResponseList(err, rows, Ingredient, callback);
+      }
+    );
+  };
+
+  /**
+    getAllRecipes fetches a list of all the Recipe objects in the system.
+    => Receives:
+      + callback: function(error, data)
+    => Returns: by calling @callback with:
+      + (null, []Recipes) the list of Recipes in the system.
+      + (Error, null) if an error occurs.
+    => Code Example:
+      // Get all the Recipes.
+      Recipes.getAllRecipes((err, listOfAllRecipes) => {
+        if (err) {
+          console.log("Failed to fetch Recipes:", err);
+          return;  // bail out of the handler here, listOfAllRecipes undefined
+        }
+        // Got the list of Rrecipes.
+        console.log("listOfAllRecipes:", listOfAllRecipes);
+        console.log("listOfAllRecipes as json", listOfAllRecipes.map(recipe => recipe.toJSON()));
+      });
+  */
+  recipes.getAllRecipes = (callback) => {
+    database.execute("SELECT * FROM Recipes", (err, rows) => {
+      if (err) {
+        callback(err, null);
+        return;
+      }
+      buildResponseList(err, rows, Recipe, callback);
+    });
+  };
+
+  return { ...recipes, Errors, Validators };
+};
+
+module.exports = { Recipes, Recipe };

--- a/database/Users.js
+++ b/database/Users.js
@@ -1,0 +1,198 @@
+const { buildResponse, buildCreateResponse, toJSON } = require("./utils");
+
+/*
+User represents a User of the system. Users have a username, password, and
+recipebook_id that maps to a RecipeBook. Every User has a unique username.
+*/
+
+// User class. A database query for User returns instances of this User class.
+class User {
+  constructor({ id, username, password, recipeBookID } = {}) {
+    this.id = id;
+    this.username = username;
+    this._password = password;
+    this.recipeBookID = Number.isInteger(recipeBookID) ? recipeBookID : -1;
+  }
+
+  // fromDatabaseRow returns an instance of the class, populating data from database row @dbRow.
+  static fromDatabaseRow(dbRow) {
+    return new User({
+      id: dbRow.id,
+      username: dbRow.username,
+      password: dbRow.password,
+      recipeBookID: dbRow.recipebook_id,
+    });
+  }
+
+  // getID returns the ID of the User.
+  getID() {
+    return this.id;
+  }
+
+  // getRecipeBookID returns the User's RecipeBook ID.
+  // If ID == -1 it means the User has no RecipeBook ID yet.
+  getRecipeBookID() {
+    return this.recipeBookID;
+  }
+
+  // toJSON returns a JSON representation of the entity with private ("_"-prefixed) fields removed.
+  toJSON() {
+    return toJSON(this);
+  }
+}
+
+// Users defines queries for Users. Instantiated with @database, a
+// reference to the mysql connection pool to be used for queries.
+const Users = (database) => {
+  // Define any Error messages or Data Validator functions for the module.
+  const Errors = {
+    notFound: "No user with that Username exists.",
+    usernameInUse: "Username is already in use.",
+    invalidUsernameOrPassword: "Invalid Username or Password.",
+  };
+
+  // TODO update these to do REAL validation that we want for our usernames and passwords.
+  const Validators = {
+    // returns True if username is valid, False if not.
+    // Note: "valid" does not mean "in use". See: Users.Errors.usernameInUse.
+    usernameIsValid: (username) => username.length > 2,
+    // returns True if password is valid, False if not.
+    passwordIsValid: (password) => password.length > 2,
+  };
+
+  // ======> BEGIN QUERIES <======
+
+  // We attach all these queries to the User object which gets returned and exported from the module.
+  const user = {};
+
+  /**
+    createUserWithUsernameAndPassword creates a new User with @username and @password.
+    => Receives:
+      + username (string)
+      + password (string)
+      + callback function(error, data)
+    => Returns: by calling @callback with:
+      + (null, Instance of the created User object) if no user with @username exists.
+      + (Users.Errors.usernameInUse, null) if the @username is already in use by another user.
+      + (Error, null) if another error occurs.
+    => Notes:
+      TODO: of course for a production system, you should hash the password and
+      store the hash, not the password in plaintext. For dev and testing, this
+      has been omitted but is crucial if you're storing real user data.
+    => Code Example:
+      Users.createUserWithUsernameAndPassword({"username": "foo", "password": "bar"}, (err, newUserObject) => {
+        if (err) {
+          if (err === Users.Errors.usernameInUse) {
+            // Inform the user they must pick a different username. newUserObject is null.
+            console.log(err);
+            return; // bail out of the handler here, newUserObject undefined
+          }
+          // Another error occurred.
+          console.log(err); // bail out of the handler here, newUserObject undefined
+        }
+        // User created successfully.
+        console.log("newUserObject:", newUserObject, "user JSON:", newUserObject.toJSON());
+      });
+  */
+  user.createUserWithUsernameAndPassword = (
+    { username, password },
+    callback
+  ) => {
+    database.execute(
+      "INSERT INTO Users(username, password)  VALUES(?, ?)",
+      [username, password],
+      (err, rows) => {
+        if (err) {
+          if (err.code === "ER_DUP_ENTRY") {
+            // mysql returns this code if a CONSTRAINT UNIQUE(username) is violated.
+            // TODO: ensure this error code is consistent when we deploy the app: if
+            // not, simply do a query in a transaction to check for prior existence.
+            callback(Errors.usernameInUse, null);
+            return;
+          }
+          callback(err, null);
+          return;
+        }
+        buildCreateResponse(err, rows, { username, password }, User, callback);
+      }
+    );
+  };
+
+  /**
+    logInWithUsernameAndPassword fetches a User having username @username and password @password.
+    => Receives:
+      + username (string)
+      + password (string)
+      + callback function(error, data)
+    => Returns: by calling @callback with:
+      + (null, Instance of the User object) if the user successfully authenticated.
+      + (Users.Errors.invalidUsernameOrPassword, null) if the @username or @password are invalid.
+      + (Error, null) if another error occurs.
+    => Code Example:
+      // Attempt to log in user with @username "foo" and @password "bar"
+      Users.logInWithUsernameAndPassword(
+        { username: "foo", password: "bar" },
+        (err, userObject) => {
+          if (err === Users.Errors.invalidUsernameOrPassword) {
+            // Let the user know they entered the wrong username or password...
+            console.log(err);
+            return; // bail out of the handler here, userObject undefined
+          }
+          // Now we have the User object. Probably set up a session here on the server
+          // and give the user a cookie to send back and send on future requests.
+          console.log("User object:", userObject, "user JSON": userObject.toJSON());
+        }
+      );
+  */
+  user.logInWithUsernameAndPassword = ({ username, password }, callback) => {
+    database.execute(
+      "SELECT * FROM Users WHERE username = ? AND password = ?",
+      [username, password],
+      (err, rows) => {
+        if (!rows || rows.length !== 1) {
+          buildResponse(Errors.invalidUsernameOrPassword, rows, User, callback);
+          return;
+        }
+        buildResponse(err, rows, User, callback);
+      }
+    );
+  };
+
+  /**
+    getUserByUsername fetches a User with username @username.
+    => Receives:
+      + username (string)
+      + callback function(error, data)
+    => Returns: by calling @callback with:
+      + (null, Instance of the User object) if such a User exists
+      + (Users.Errors.notFound, null) if no such User with @username can be found.
+      + (Error, null) if another error occurs.
+    => Code Example:
+      // Fetch a User by username foo, if user exists.
+      Users.getUserByUsername({ username: "foo" }, (err, userObject) => {
+        if (err) {
+          console.log("Couldn't fetch user. Error:", err);
+          return; // bail out of the handler here, userObject undefined
+        }
+        // Do something with the User object.
+        console.log("userObject:", userObject, "json:", userObject.toJSON());
+      });
+  */
+  user.getUserByUsername = ({ username }, callback) => {
+    database.execute(
+      "SELECT * FROM Users WHERE username = ?",
+      [username],
+      (err, rows) => {
+        if (!rows || rows.length === 0) {
+          buildResponse(Errors.notFound, rows, User, callback);
+          return;
+        }
+        buildResponse(err, rows, User, callback);
+      }
+    );
+  };
+
+  return { ...user, Errors, Validators };
+};
+
+module.exports = { Users, User };

--- a/database/client.js
+++ b/database/client.js
@@ -1,5 +1,4 @@
-// client.js sets up the database client for queries and provides an
-// "Am I connected?" sanity check with describeTables(). Could add
+// client.js sets up the database client for queries. Could add
 // more in the way of connection management if needed.
 
 // Set-up adapted from docs here: https://www.npmjs.com/package/mysql2.
@@ -27,25 +26,4 @@ const pool = mysql.createPool({
   queueLimit: 0,
 });
 
-// describeTables runs DESCRIBE Users and DESCRIBE RecipeBooks so we can know
-// the DB connection is working and the initialization script was successful.
-
-const describeTables = () => {
-  // Describe the two tables we should be creating so far in database-definitions.sql.
-  pool.query("DESCRIBE Users;", function (err, results, fields) {
-    if (err) {
-      console.log(`error: ${err}`); // any error
-    }
-    console.log(results); // results contains rows returned by server
-    // console.log(fields); // fields contains extra meta data about results, if available
-  });
-  pool.query("DESCRIBE RecipeBooks;", function (err, results, fields) {
-    if (err) {
-      console.log(`error: ${err}`); // any error
-    }
-    console.log(results); // results contains rows returned by server
-    // console.log(fields); // fields contains extra meta data about results, if available
-  });
-};
-
-module.exports = { describeTables };
+module.exports = { pool };

--- a/database/database-definitions.sql
+++ b/database/database-definitions.sql
@@ -6,17 +6,38 @@
 
 -- Using the CHARACTER SET=utf8mb4; flag allows for Unicode characters (non-ASCII), including emoji :)
 
--- TODO: Tables To be defined
--- Recipes
--- Ingredients
--- RecipeIngredients
-
 CREATE DATABASE IF NOT EXISTS EthicalEating;
 USE EthicalEating;
+
+-- Creates the recipe table based on schema design
+CREATE TABLE IF NOT EXISTS Recipes(
+  id INT AUTO_INCREMENT NOT NULL PRIMARY KEY,
+  name VARCHAR(255) NOT NULL,
+  is_public BOOLEAN NOT NULL,
+  date_created DATE
+) CHARACTER SET=utf8mb4;
+
+-- Creates the Ingredients table based on schema design
+CREATE TABLE IF NOT EXISTS Ingredients(
+  id INT AUTO_INCREMENT NOT NULL PRIMARY KEY,
+  name VARCHAR(255),
+  description VARCHAR(255),
+  ethical_score INT
+) CHARACTER SET=utf8mb4;
+
+-- Creates the RecipeIngredients table based on schema design
+CREATE TABLE IF NOT EXISTS RecipeIngredients(
+  id INT NOT NULL AUTO_INCREMENT PRIMARY KEY,
+  ingredient_id INT,
+  recipe_id INT,
+  FOREIGN KEY (ingredient_id) REFERENCES Ingredients (id) ON DELETE CASCADE ON UPDATE CASCADE,
+  FOREIGN KEY (recipe_id) REFERENCES Recipes (id) ON DELETE CASCADE ON UPDATE CASCADE
+) CHARACTER SET=utf8mb4;
 
 CREATE TABLE IF NOT EXISTS Users(
   id INT NOT NULL AUTO_INCREMENT PRIMARY KEY,
   username VARCHAR(99) NOT NULL,
+  recipebook_id INT NOT NULL DEFAULT -1,
   password VARCHAR(99) NOT NULL,
   CONSTRAINT UNIQUE(username)
 ) CHARACTER SET=utf8mb4;
@@ -24,25 +45,23 @@ CREATE TABLE IF NOT EXISTS Users(
 CREATE TABLE IF NOT EXISTS RecipeBooks(
   id INT NOT NULL AUTO_INCREMENT PRIMARY KEY,
   owner_id INT NOT NULL,
-  FOREIGN KEY (owner_id) REFERENCES Users (id) ON DELETE CASCADE ON UPDATE CASCADE
+  -- Only allow a single RecipeBook per User.
+  CONSTRAINT UNIQUE(owner_id),
+  FOREIGN KEY(owner_id) REFERENCES Users (id) ON UPDATE CASCADE
 ) CHARACTER SET=utf8mb4;
 
--- TODO: commented out for now because creation fails since Recipes doesn't exist yet :)
--- See TABLES TO BE DEFINED at top.
--- CREATE TABLE IF NOT EXISTS RecipeBookRecipes(
---   id INT NOT NULL AUTO_INCREMENT PRIMARY KEY,
---   recipe_id INT NOT NULL,
---   recipebook_id INT NOT NULL,
---   FOREIGN KEY (recipe_id) REFERENCES Recipes (id)
---   FOREIGN KEY (recipebook_id) REFERENCES RecipeBooks (id)
--- ) CHARACTER SET=utf8mb4;
+CREATE TABLE IF NOT EXISTS RecipeBookRecipes(
+  id INT NOT NULL AUTO_INCREMENT PRIMARY KEY,
+  recipe_id INT NOT NULL,
+  recipebook_id INT NOT NULL,
+  FOREIGN KEY (recipe_id) REFERENCES Recipes (id),
+  FOREIGN KEY (recipebook_id) REFERENCES RecipeBooks (id)
+) CHARACTER SET=utf8mb4;
 
--- TODO: commented out for now because creation fails since Ingredients doesn't exist yet :)
--- See TABLES TO BE DEFINED at top.
--- CREATE TABLE IF NOT EXISTS IngredientReplacements(
---     id INT NOT NULL AUTO_INCREMENT PRIMARY KEY,
---     ingredient_id_replaces INT NOT NULL,
---     ingredient_id_replacement INT NOT NULL,
---     FOREIGN KEY (ingredient_id_replaces) REFERENCES Ingredients (id)
---     FOREIGN KEY (ingredient_id_replacement) REFERENCES Ingredients (id)
--- ) CHARACTER SET=utf8mb4;
+CREATE TABLE IF NOT EXISTS IngredientReplacements(
+  id INT NOT NULL AUTO_INCREMENT PRIMARY KEY,
+  ingredient_id_replaces INT NOT NULL,
+  ingredient_id_replacement INT NOT NULL,
+  FOREIGN KEY (ingredient_id_replaces) REFERENCES Ingredients (id),
+  FOREIGN KEY (ingredient_id_replacement) REFERENCES Ingredients (id)
+) CHARACTER SET=utf8mb4;

--- a/database/index.js
+++ b/database/index.js
@@ -1,0 +1,29 @@
+// This module exports the different Entity models, instantiating
+// each of them with a handle to the database connection pool that
+// the models will use to perform queries.
+
+const { pool } = require("./client");
+
+// Import these models into your Route handlers where needed. For instance:
+// const {
+//   Users, Recipes, RecipeBooks, Ingredients, RecipeBookRecipes, IngredientReplacements
+// } = require("./database");
+// You can then use the methods on the models you imported.
+// See the models modules in this folder for documentation and examples.
+const { Users } = require("./Users");
+const { Recipes } = require("./Recipes");
+const { RecipeBooks } = require("./RecipeBooks");
+const { Ingredients } = require("./Ingredients");
+const { RecipeBookRecipes } = require("./RecipeBookRecipes");
+const { IngredientReplacements } = require("./IngredientReplacements");
+
+// Export an instance of each model, instantiated with pool.
+// TODO: Should these be singletons / have some factory fn?
+module.exports = {
+  Users: Users(pool),
+  Recipes: Recipes(pool),
+  RecipeBooks: RecipeBooks(pool),
+  Ingredients: Ingredients(pool),
+  RecipeBookRecipes: RecipeBookRecipes(pool),
+  IngredientReplacements: IngredientReplacements(pool),
+};

--- a/database/utils.js
+++ b/database/utils.js
@@ -1,0 +1,75 @@
+// utils.js contains some "utility functions" used throughout to help prepare
+// database responses to the backend client or perform common tasks like null
+// checking, etc.
+
+// buildCreateResponse checks the database response for any errors @err and calls the
+// @callback function with the appropriate (err, data) response. Used for initial
+// entity creation: adds the insertId to the object. If data is present, it calls the
+// @callback with an instance of class of type @entity instantiated with data from @rows.
+const buildCreateResponse = (err, rows, creationParams, entity, callback) => {
+  if (!nullOrUndefined(err)) {
+    callback(err, null);
+    return;
+  }
+  if (nullOrUndefined(rows) || nullOrUndefined(rows.insertId)) {
+    callback(null, null);
+    return;
+  }
+  callback(null, new entity({ id: rows.insertId, ...creationParams }));
+};
+
+// buildResponse checks the database response for any errors @err and calls the
+// @callback function with the appropriate (err, data) response. If data is present,
+// it calls the @callback with an instance of class of type @entity instantiated
+// with data from @rows.
+const buildResponse = (err, rows, entity, callback) => {
+  if (!nullOrUndefined(err)) {
+    callback(err, null);
+    return;
+  }
+  if (nullOrUndefined(rows) || !rows.length) {
+    callback(null, null);
+    return;
+  }
+  callback(null, entity.fromDatabaseRow(rows[0]));
+};
+
+// buildResponseList checks the database response for any errors @err and calls the
+// @callback function with the appropriate (err, data) response. If data is present, it
+// calls the @callback with a list of instances of class of type @entity instantiated
+// with data from @rows.
+const buildResponseList = (err, rows, entity, callback) => {
+  if (!nullOrUndefined(err)) {
+    callback(err, null);
+    return;
+  }
+  if (nullOrUndefined(rows) || !rows.length) {
+    callback(null, []);
+    return;
+  }
+  callback(
+    null,
+    rows.map((row) => entity.fromDatabaseRow(row))
+  );
+};
+
+// nullOrUndefined returns True if @obj is null or of type undefined, False if not.
+const nullOrUndefined = (obj) => obj === null || typeof obj === "undefined";
+
+// toJSON returns a JSON representation of all keys in object, except for any
+// "private" ("_"-prefixed) keys that should not be included.
+const toJSON = (obj) => {
+  const publicObj = {};
+  Object.keys(obj)
+    .filter((key) => key.length === 0 || key[0] !== "_") // filter out empty (don't think possible...) or private ("_"-prefixed keys)
+    .forEach((publicKey) => (publicObj[publicKey] = obj[publicKey])); // return the key-value pair for each public key
+  return publicObj;
+};
+
+module.exports = {
+  buildCreateResponse,
+  buildResponse,
+  buildResponseList,
+  nullOrUndefined,
+  toJSON,
+};

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,13 +9,29 @@ services:
     volumes:
       - ./database/database-definitions.sql:/data/application/init.sql
     ports:
+      # If you uncomment the "127.0.0.1:3306:3306", you expose the database to port 3306 locally,
+      # and you can connect to your database using MySQL Workbench tool
+      # https://www.mysql.com/products/workbench/ -- create a connection to 127.0.0.1
+      # port 3306, user "root" password "secret". If it is just "3306" then it is
+      # only available from another Docker container running in this compose file.
+      # See: https://stackoverflow.com/a/46220742
       - "3306"
+      # - "127.0.0.1:3306:3306"
   webapp:
     build:
       context: .
       dockerfile: webapp_dockerfile
-    command: "npm start"
+    command: "npm run dev"
     depends_on:
       - "db"
     ports:
       - "6377:6377"
+    volumes:
+      # Map your local working directory to the app folder so nodemon
+      # will notice when it changes to enable hot reload.
+      - .:/app
+      - node_modules:/app/node_modules
+volumes:
+  # Create an empty volume so that local node_modules folder does not get
+  # mounted into app container and override it.
+  node_modules:

--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
   "main": "app.js",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
-    "start": "node app.js"
+    "start": "node app.js",
+    "dev": "npx nodemon app.js"
   },
   "repository": {
     "type": "git",
@@ -22,5 +23,8 @@
     "express-handlebars": "^5.2.0",
     "handlebars": "^4.7.6",
     "mysql2": "^2.2.5"
+  },
+  "devDependencies": {
+    "nodemon": "^2.0.6"
   }
 }


### PR DESCRIPTION
This PR does the following things:

* small tweaks to the schema
* add hot reloading capability with nodemon, db debugging instructions
* remove the "demo" db route
* add some database utility functions
* add database models and functions for Entities
* add exporting index file, explain purpose
* merge database schemas

There's now a "bridge" layer to map Application objects to Database objects and back with model-specific functions for Users, Recipes, RecipeBooks, RecipeBookRecipes, Ingredients, and IngredientReplacements.

This way application-specific queries can be defined in the associated model and the application does not have to know about the Database (and vice versa). This way we can separate Business Logic concerns from Storage concerns, meaning it should be easy to let either of these layer vary with minimal changes required in the other, due to the bridged interface between them.

I tried to document the queries for each model extensively, provided an example route in app.js that you can delete (just a demo!) and tried to use the /** documentation style so that if you're using an editor like Visual Studio Code, the docs will auto-complete in the tool tips.