### PR TITLE
Fix up docker-compose issues Xander saw with bcrypt install

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,1 @@
+node_modules

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -30,8 +30,4 @@ services:
       # Map your local working directory to the app folder so nodemon
       # will notice when it changes to enable hot reload.
       - .:/app
-      - node_modules:/app/node_modules
-volumes:
-  # Create an empty volume so that local node_modules folder does not get
-  # mounted into app container and override it.
-  node_modules:
+      - /app/node_modules

--- a/webapp_dockerfile
+++ b/webapp_dockerfile
@@ -1,10 +1,3 @@
-# FROM node:6.10.2-alpine
-# The above line is what's running on flip. It doesn't work with
-# express-handlebars due to use of async.
-
-# Temporarily using a later version of Node so we can use async and such here.
-# But this must be resolved soon.
-
 FROM node:12.19.0-alpine
 WORKDIR /app
 COPY package.json /app


### PR DESCRIPTION
I found these changes fixed the issue of bcrypt not being recognized after running the following steps:

1. Remove node_modules in your local directory.
2. Run npm install again.
3. `docker-compose build --no-cache`
4. `docker-compose up -d --force-recreate`