### PR TITLE
Parse unnecessary, use mysql:8

### DIFF
--- a/database/Recipes.js
+++ b/database/Recipes.js
@@ -229,7 +229,6 @@ const Recipes = (database) => {
       "SELECT * FROM RecipeItsIngredientsAndTheirReplacements WHERE UPPER(name) LIKE ?",
       ["%" + query.toUpperCase() + "%"],
       (err, rows) => {
-        console.log(err, rows);
         if (err) {
           callback(err, null);
           return;
@@ -241,16 +240,13 @@ const Recipes = (database) => {
           recipeIDToData[row.id]["ingredients"] = {};
           const thisIngredient = recipeIDToData[row.id]["ingredients"];
           if (!nullOrUndefined(row.ingredients_and_replacements)) {
-            console.log("Row", row.ingredients_and_replacements);
-            const parsed = JSON.parse(row.ingredients_and_replacements);
-            console.log("Parsed", parsed);
-            parsed.forEach((iar) => {
+            row.ingredients_and_replacements.forEach((iar) => {
               const ID = iar.ingredient.id;
               thisIngredient[ID] = {};
               thisIngredient[ID]["ingredient"] = Ingredient.fromDatabaseRow(iar.ingredient).toJSON();
               thisIngredient[ID]["replacements"] = [];
-              if (iar.replacements !== null) {
-                thisIngredient[ID]["replacements"] = JSON.parse(iar.replacements).map((r) => ({
+              if (!nullOrUndefined(iar.replacements)) {
+                thisIngredient[ID]["replacements"] = iar.replacements.map((r) => ({
                   ...Ingredient.fromDatabaseRow(r).toJSON(),
                   ...IngredientReplacement.fromDatabaseRow(r).toJSON(),
                 }));

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 version: "3.8"
 services:
   db:
-    image: mariadb
+    image: mysql:8
     environment:
       MYSQL_ROOT_PASSWORD: secret
     # https://stackoverflow.com/a/43331395 init database by running database-definitions.sql file


### PR DESCRIPTION
There was a difference in how mysql8 and mariadb were handling the JSON functions. This update docker-compose to use mysql:8 which is equivalent to the version of JawsDB https://elements.heroku.com/addons/jawsdb that we're using on Heroku.