### PR TITLE
Enable Ingredient substitutions for private RecipeBook Recipes

### DIFF
--- a/app.js
+++ b/app.js
@@ -174,7 +174,7 @@ app.post('/addRecipe', function (req, res) {
 	Recipes.clone({"recipeID": recipeID, "username": req.session.user_id}, function(err, newRecipeID) {
 		if (err) {
 			console.log("clone failed err:", err);
-			return res.status(500).json("failedToAddRecipe");
+			return res.status(500).json({"error": err});
 		}
 		RecipeBooks.addRecipeByIDToRecipeBookWithID({ "recipeID": newRecipeID, "recipeBookID": req.session.recipeBookID }, function (err, data) {
 			if (err) {

--- a/database/database-definitions.sql
+++ b/database/database-definitions.sql
@@ -16,7 +16,8 @@ CREATE TABLE IF NOT EXISTS Recipes(
   name VARCHAR(255) NOT NULL,
   is_public BOOLEAN NOT NULL,
   date_created DATE,
-  owner_id INT
+  owner_id INT,
+  CONSTRAINT UNIQUE(name, owner_id)
 ) CHARACTER SET=utf8mb4;
 
 -- Creates the Ingredients table based on schema design

--- a/public/css/book.css
+++ b/public/css/book.css
@@ -7,7 +7,7 @@
 }
 
 table {
-    display: block;
+    width: 80vw;
     border: 2px solid;
     border-collapse: collapse;
     Overflow-y: scroll;
@@ -20,7 +20,6 @@ th, td {
 }
 
 tbody {
-    display: block;
     width: 100%;
 }
 
@@ -29,12 +28,35 @@ th {
     font-size: large;
 }
 
-#ethicalInfo {
-    min-width:39em;
+td {
+    padding: 0px 8px;
+}
+
+input {
+    cursor: pointer;
+}
+
+input[type='radio'] {
+    width: 16px;
+    height: 16px;
+    margin-right: 8px;
+}
+
+label {
+    display: inline;
+}
+
+div.ingredientReplacementSuggestion {
+    margin: 16px auto;
 }
 
 .sortIcon:hover {
     color:slategrey;
+}
+
+a span.tooltiptext {
+    text-decoration: underline;
+    color: blue;
 }
 
 #recipeClick:hover {

--- a/public/js/book.js
+++ b/public/js/book.js
@@ -9,15 +9,91 @@ function addRecipe(recipeID) {
         },
         body: JSON.stringify({ recipeID: recipeID })
     };
-    fetch('/addRecipe', options).then(data => {
+    fetch('/addRecipe', options)
+        .then(data => data.json())
+        .then(result => {
         // Success! Redirect to recipe page.
-        window.location.href = "/book";
+        if (result.error !== null && typeof result.error !== "undefined") {
+            window.alert(result.error);
+        } else {
+            window.location.href = "/book";
+        }
     }).catch(err => {
         // There was an error, display this to the user.
         console.log("Error :(", err);
-    })
+    });
 };
 
+
+function handleIngredientReplacementFormSubmit(event) {
+    // Prevent default submit behavior.
+    event.preventDefault();
+
+    const replaceWith = document.querySelector(
+      `input[name="replaceWithID"]:checked`
+    ).value;
+    let replaceWithID = null;
+    if (replaceWith !== "null" && Number.isInteger(Number(replaceWith))) {
+      replaceWithID = Number(replaceWith);
+    }
+
+    const originalID = document.querySelector(
+      `input[name="originalIngredientID"]`
+    ).value;
+    let toReplaceID = null;
+    if (originalID !== null && Number.isInteger(Number(originalID))) {
+      toReplaceID = Number(originalID);
+    }
+
+    const urlObj = new URL(window.location.href);
+    const recipeIDParam = urlObj.searchParams.get("recipeID");
+
+    let recipeID = null;
+    if (recipeIDParam !== null && Number.isInteger(Number(recipeIDParam))) {
+      recipeID = Number(recipeIDParam);
+    }
+
+    if (toReplaceID === null || replaceWithID === null || recipeID === null) {
+      console.log(
+        "one or more require params null,",
+        toReplaceID,
+        replaceWithID,
+        recipeID
+      );
+      return;
+    }
+
+    const options = {
+      method: "PATCH",
+      headers: {
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({ toReplaceID, replaceWithID }),
+    };
+    // recipe ID query parameter
+    fetch(`/userRecipe/${recipeID}/ingredients`, options)
+      .then(data => data.json())
+      .then(result => {
+        // Success! Redirect to recipe page.
+        if (result.error) {
+            console.log("Replacement error:", result.error);
+            return;
+        }
+        // Go back to the recipe page.
+        history.back();
+      })
+      .catch((err) => {
+        // There was an error, display this to the user.
+        console.log("Replacement Error :(", err);
+      });
+}
+
+function attachListeners() {
+    const ingredientReplacementForm = document.getElementById("submitIngredientReplacement");
+    if (ingredientReplacementForm) {
+        ingredientReplacementForm.addEventListener("submit", handleIngredientReplacementFormSubmit);
+    }
+};
 
 /*-----------------------------------------------------------------------------------*/
 /* Table sort code citation: https://www.w3schools.com/howto/howto_js_sort_table.asp */
@@ -80,3 +156,4 @@ function sortTable(n) {
     }
 }
 
+document.addEventListener("DOMContentLoaded", attachListeners);

--- a/routes/ethicalRouter.js
+++ b/routes/ethicalRouter.js
@@ -61,13 +61,9 @@ ethicalRouter.route('/:ingredientId')
           console.log("Failed to get IngredientReplacements:", err);
           return; // bail out of the handler here, listOfIngredientObjects undefined
         }
-        console.log("Fetched listOfIngredientReplacements:", listOfIngredientObjects);
-        console.log("List as JSON objects",
-          listOfIngredientObjects.map((ingredient) =>
-            ingredient.toJSON()
-          )
-        );
+        context.originalIngredient = ingredientObject;
         context.ingredientReplacements = listOfIngredientObjects;
+        console.log(context);
         res.render('ingredientEthics', context);
       }
     );

--- a/routes/recipesRouter.js
+++ b/routes/recipesRouter.js
@@ -6,6 +6,21 @@ const recipesRouter = express.Router();
 recipesRouter.use(bodyParser.urlencoded({ extended: false }));
 recipesRouter.use(bodyParser.json());
 
+recipesRouter.route("/:recipeID/ingredients").patch((req, res, next) => {
+  const recipeID = Number(req.params.recipeID);
+  const { toReplaceID, replaceWithID } = req.body;
+  Models.Recipes.replaceIngredientForRecipeID(
+    { toReplaceID, replaceWithID, recipeID },
+    function (err, _) {
+      if (err !== null) {
+        res.status(500).json(err);
+        return;
+      }
+      res.status(200).json("OK");
+    }
+  );
+});
+
 recipesRouter.route("/:recipeID").get((req, res, next) => {
   context = {};
   Models.Recipes.getByIDWithIngredientsAndReplacements(
@@ -14,9 +29,9 @@ recipesRouter.route("/:recipeID").get((req, res, next) => {
       if (err) {
         console.log("Failed to fetch Recipe ID:", req.params.recipeID, err);
         return next(err); // bail out of the handler here, recipeWithReplacements undefined
-        }
-        context.ingredients = recipeWithReplacements
-        res.render('userRecipe', context);
+      }
+      context.ingredients = recipeWithReplacements;
+      res.render("userRecipe", context);
     }
   );
 });

--- a/views/ingredientEthics.handlebars
+++ b/views/ingredientEthics.handlebars
@@ -1,10 +1,10 @@
 ﻿<head>
-    <link rel="stylesheet" href="/css/book.css" />
+    <link rel="stylesheet" href="/css/book.css?v=1605124590" />
 </head>
-<div style="margin-left: 10%; margin-right: 10%;">
+<div>
     <p>
-        <button onclick="history.back()" style="height:4em;width:16em;font-size:medium">
-            Back to [Recipe]
+        <button onclick="history.back()" style="height:4em;width:16em;margin-left:4em;font-size:medium">
+            <-- Back to Recipe
         </button>
     </p>
 
@@ -22,19 +22,16 @@
                 You could consider replacing it with one of the following options.</p>
                 <br/>
             <h3><b>Replacement Suggestions</b></h3>
-            <form>
+            <form id="submitIngredientReplacement">
 
             {{#each ingredientReplacements}}
-                <input type="radio" id="replacement_1" name="replaceIngredient" value="replacement 1">
-                <label for="replacement_1">{{replacementReason}} <a href="{{replacementReasonSource}}" target="_blank">[source]</a></label>
-                <span class="tooltip">
-                    &#11217
-                    <span class='tooltiptext'>This ingredient is more ethical because it uses less water!</span>
-                </span>
-                <br />
+            <div class="ingredientReplacementSuggestion">
+                <input type="radio" id="replacement_{{@index}}" name="replaceWithID" value="{{id}}">
+                <label for="replacement_{{@index}}">{{replacementReason}} <a href="{{replacementReasonSource}}" target="_blank">[source]</a></label>
+            </div>
             {{/each}}
-                <input type="radio" id="no_change" name="replaceIngredient" value="no_change" checked>
-
+                <input type="hidden" name="originalIngredientID" value="{{originalIngredient.id}}">
+                <input type="radio" id="no_change" name="replaceWithID" value="null" checked>
                 <label for="no_change">No thanks, I'll keep it as is</label><br /><br />
 
                 <input type="submit" value="Replace Ingredient">
@@ -54,4 +51,4 @@
 
 </div>
 
-<script src="/js/book.js"></script>
+<script src="/js/book.js?v=1605124590"></script>

--- a/views/userRecipe.handlebars
+++ b/views/userRecipe.handlebars
@@ -1,5 +1,5 @@
 ﻿<head>
-    <link rel="stylesheet" href="/css/book.css" />
+    <link rel="stylesheet" href="/css/book.css?v=1605124590" />
 </head>
 <div style="margin-left: 10%; margin-right: 10%;">
     <h1 id="recipeBookHomeTitle">{{ingredients.recipe.name}}</h1><br />
@@ -29,7 +29,7 @@
             <td>
                 {{#if this.replacements}}
                     <span class="tooltipleft" style="float:right">
-                        <a href="/ingredientEthics/{{this.ingredient.id}}">&#9432
+                        <a href="/ingredientEthics/{{this.ingredient.id}}?recipeID={{../ingredients.recipe.id}}">&#9432
                         <span class="tooltiptext">
                             How can I ethically improve this ingredient?
                         </span>
@@ -134,4 +134,4 @@
 
 </div>
 
-<script src="/js/book.js"></script>
+<script src="/js/book.js?v=1605124590"></script>


### PR DESCRIPTION
This PR enables Ingredient substitutions for private RecipeBook Recipes. A user can now substitute problematic ingredients with better options if they desire. Ability to "undo" / confirm replacements still TBD, future task this sprint.

For now if the user attempts to "Add a recipe to my recipe book" from the search page, and the user already has a recipe by that name, the addition will fail with a window.alert() message. This prevents the user from having duplicate Recipes in their book with the same name.

https://app.asana.com/0/home/1196362888073108/1199161451365933