### PR TITLE
Fix 3 code smells

### DIFF
--- a/app.js
+++ b/app.js
@@ -52,21 +52,7 @@ app.use(function(req, res, next){
 
 app.set('view engine', 'handlebars');
 
-// Demo of how to create and log in a user...
 const { Users, RecipeBooks } = require('./database');
-const { check } = require('express-validator');
-const { read } = require('fs');
-const { RecipeBook } = require('./database/RecipeBooks');
-const RecipeBookRecipes = require('./database/RecipeBookRecipes');
-app.get('/demo', (_, res) => {
-	Users.createUserWithUsernameAndPassword({ username: 'foo', password: 'bar' }, (error, user) => {
-		console.log('user creation error:', error, 'newly created user:', user);
-		Users.logInWithUsernameAndPassword({ username: 'foo', password: 'bar' }, (error, user) => {
-			console.log('login error:', error, 'logged in user:', user);
-		});
-	});
-	res.status(200).send('demo ok');
-});
 
 // Run this program as a parameter on any page that requires login
 // See '/secret' page for example

--- a/database/IngredientReplacements.js
+++ b/database/IngredientReplacements.js
@@ -57,90 +57,6 @@ const IngredientReplacements = (database) => {
   const ingredientReplacement = {};
 
   /**
-    createIngredientReplacement creates an IngredientReplacement replacing Ingredient with
-    ID @ingredientIDReplaces with Ingredient with ID @ingredientIDReplacement for ethical
-    reason @replacementReason.
-
-    Creation fails if either of the two Ingredients do not exist or if the Ingredient IDs are
-    the same (since an Ingredient cannot replace itself).
-    => Receives:
-      + ingredientIDReplaces: ID of the Ingredient A to replace.
-      + ingredientIDReplacement: ID of the Ingredient to replace Ingredient A with.
-      + replacementReason: Description of the reason why we are making the replacement.
-      + replacementReasonSource: Source for the rationale we're using to suggest the replacement.
-      + callback: function(error, data)
-    => Returns: by calling @callback with:
-      + (null, Instance of created IngredientReplacement object) on creation success.
-      + (Error, null) if an error occurs.
-    */
-  ingredientReplacement.createIngredientReplacement = (
-    { ingredientIDReplaces, ingredientIDReplacement, replacementReason },
-    callback
-  ) => {
-    if (ingredientIDReplaces === ingredientIDReplacement) {
-      callback(
-        new Error(
-          "You cannot create an IngredientReplacement that replaces an Ingredient with itself."
-        ),
-        null
-      );
-      return;
-    }
-    database.execute(
-      `
-      INSERT INTO IngredientReplacements(ingredient_id_replaces, ingredient_id_replacement, replacement_reason, replacement_reason_source)
-      VALUES (?, ?, ?, ?)
-      `,
-      [
-        ingredientIDReplaces,
-        ingredientIDReplacement,
-        replacementReason,
-        replacementReasonSource,
-      ],
-      (err, rows) =>
-        buildCreateResponse(
-          err,
-          rows,
-          {
-            ingredientIDReplaces,
-            ingredientIDReplacement,
-            replacementReason,
-            replacementReasonSource,
-          },
-          IngredientReplacement,
-          callback
-        )
-    );
-  };
-
-  /**
-    getReplacementsForIngredient returns a list of IngredientReplacements for Ingredient
-    with ID @ingredientIDToReplace. The list may be empty if no replacements exist or
-    if the Ingredient with @ingredientIDToReplace does not exist.
-    => Receives:
-      + ingredientIDToReplace: ID of the Ingredient to find IngredientReplacements for.
-      + callback: function(error, data)
-    => Returns: by calling @callback with:
-      + (null, []IngredientReplacement objects) on query success. List may be empty.
-      + (Error, null) if an error occurs.
-  */
-  ingredientReplacement.getReplacementsForIngredient = (
-    { ingredientID },
-    callback
-  ) => {
-    database.execute(
-      "SELECT * FROM IngredientReplacements WHERE ingredient_id_replaces = ?",
-      [ingredientID],
-      (err, rows) => {
-        if (err) {
-          callback(err, null);
-        }
-        buildResponseList(err, rows, IngredientReplacement, callback);
-      }
-    );
-  };
-
-  /**
     getReplacementsForIngredientAsIngredientObjects returns a list of Ingredients for each
     IngredientReplacement that we suggest for the Ingredient with the ID @ingredientIDToReplace.
     The list may be empty if no replacements exist or if the Ingredient with @ingredientIDToReplace
@@ -180,7 +96,7 @@ const IngredientReplacements = (database) => {
     );
   };
 
-  return { ...ingredientReplacement, Errors, Validators };
+  return { ...ingredientReplacement, Errors };
 };
 
 module.exports = { IngredientReplacements, IngredientReplacement };

--- a/database/IngredientReplacements.js
+++ b/database/IngredientReplacements.js
@@ -73,20 +73,6 @@ const IngredientReplacements = (database) => {
     => Returns: by calling @callback with:
       + (null, Instance of created IngredientReplacement object) on creation success.
       + (Error, null) if an error occurs.
-    => Code Example:
-      // Create an IngredientReplacement, replacing Ingredient with ID = 1 with Ingredient with
-      // ID = 2 for reason @replacementReason.
-      IngredientReplacements.createIngredientReplacement({
-        ingredientIDReplaces: 1,
-        ingredientIDReplacement: 2,
-        replacementReason: "This ingredient requires less water to produce.",
-      }, (err, newIngredientReplacement) => {
-        if (err) {
-          console.log("Failed to create IngredientReplacement:", err);
-          return; // bail out of the handler here, newIngredientReplacement undefined
-        }
-        console.log("Created newIngredientReplacement:", newIngredientReplacement, "json: ", newIngredientReplacement.toJSON());
-      });
     */
   ingredientReplacement.createIngredientReplacement = (
     { ingredientIDReplaces, ingredientIDReplacement, replacementReason },
@@ -138,23 +124,6 @@ const IngredientReplacements = (database) => {
     => Returns: by calling @callback with:
       + (null, []IngredientReplacement objects) on query success. List may be empty.
       + (Error, null) if an error occurs.
-    => Code Example:
-      // Find IngredientReplacements for Ingredient with @ingredientID = 1.
-      IngredientReplacements.getReplacementsForIngredient(
-        { ingredientID: 1 },
-        (err, listOfIngredientReplacements) => {
-          if (err) {
-            console.log("Failed to get IngredientReplacements:", err);
-            return; // bail out of the handler here, listOfIngredientReplacements undefined
-          }
-          console.log("Fetched listOfIngredientReplacements:", listOfIngredientReplacements);
-          console.log("List as JSON objects",
-            listOfIngredientReplacements.map((ingredientReplacement) =>
-              ingredientReplacement.toJSON()
-            )
-          );
-        }
-      );
   */
   ingredientReplacement.getReplacementsForIngredient = (
     { ingredientID },
@@ -183,23 +152,6 @@ const IngredientReplacements = (database) => {
     => Returns: by calling @callback with:
       + (null, []Ingredient objects) on query success. List may be empty.
       + (Error, null) if an error occurs.
-    => Code Example:
-      // Find IngredientReplacements for Ingredient with @ingredientIDToReplace = 19.
-      IngredientReplacements.getReplacementsForIngredientAsIngredientObjects(
-        { ingredientIDToReplace: 19 },
-        (err, listOfIngredientObjects) => {
-          if (err) {
-            console.log("Failed to get IngredientReplacements:", err);
-            return; // bail out of the handler here, listOfIngredientObjects undefined
-          }
-          console.log("Fetched listOfIngredientReplacements:", listOfIngredientObjects);
-          console.log("List as JSON objects",
-            listOfIngredientObjects.map((ingredient) =>
-              ingredient.toJSON()
-            )
-          );
-        }
-      );
   */
 
   ingredientReplacement.getReplacementsForIngredientAsIngredientObjects = (

--- a/database/IngredientReplacements.js
+++ b/database/IngredientReplacements.js
@@ -48,9 +48,8 @@ class IngredientReplacement {
 // IngredientReplacements. Defines queries for IngredientReplacements. Instantiated with
 // @database, a reference to the mysql connection pool to be used for queries.
 const IngredientReplacements = (database) => {
-  // Define any Error messages or Data Validator functions for the module.
+  // Define any Error messages for the module.
   const Errors = {};
-  const Validators = {};
 
   // ======> BEGIN QUERIES <======
 

--- a/database/Ingredients.js
+++ b/database/Ingredients.js
@@ -42,11 +42,10 @@ class Ingredient {
 // Ingredients defines queries for Ingredients. Instantiated with @database,
 // a reference to the mysql connection pool to be used for queries.
 const Ingredients = (database) => {
-  // Define any Error messages or data Validator functions for the module.
+  // Define any Error messages for the module.
   const Errors = {
     notFound: "That ingredient does not exist.",
   };
-  const Validators = {};
 
   // ======> BEGIN QUERIES <======
 
@@ -155,7 +154,7 @@ const Ingredients = (database) => {
     );
   };
 
-  return { ...ingredients, Errors, Validators };
+  return { ...ingredients, Errors };
 };
 
 module.exports = { Ingredients, Ingredient };

--- a/database/Ingredients.js
+++ b/database/Ingredients.js
@@ -60,15 +60,15 @@ const Ingredients = (database) => {
       + (null, []Ingredients) the list of Ingredients in the system.
       + (Error, null) if an error occurs.
   */
- ingredients.getAllIngredients = (callback) => {
-  database.execute("SELECT * FROM Ingredients", (err, rows) => {
-    if (err) {
-      callback(err, null);
-      return;
-    }
-    buildResponseList(err, rows, Ingredient, callback);
-  });
-};
+  ingredients.getAllIngredients = (callback) => {
+    database.execute("SELECT * FROM Ingredients", (err, rows) => {
+      if (err) {
+        callback(err, null);
+        return;
+      }
+      buildResponseList({ err, rows, callback, entity: Ingredient });
+    });
+  };
 
   /**
     getIngredient fetches the Ingredient with ID @ingredientID if it exists.
@@ -92,7 +92,7 @@ const Ingredients = (database) => {
         if (!rows || rows.length !== 1) {
           callback(Errors.notFound, null);
         }
-        buildResponse(err, rows, Ingredient, callback);
+        buildResponse({ err, rows, callback, entity: Ingredient });
       }
     );
   };
@@ -117,7 +117,7 @@ const Ingredients = (database) => {
           callback(err, null);
           return;
         }
-        buildResponseList(err, rows, Ingredient, callback);
+        buildResponseList({ err, rows, callback, entity: Ingredient });
       }
     );
   };

--- a/database/Ingredients.js
+++ b/database/Ingredients.js
@@ -53,37 +53,6 @@ const Ingredients = (database) => {
   const ingredients = {};
 
   /**
-    createIngredient creates a new Ingredient with name @name and description @description.
-    => Receives:
-      + name: Name of the Ingredient.
-      + description: Description of the Ingredient.
-      + callback: function(error, data)
-    => Returns: by calling @callback with:
-      + (null, Ingredient) with the Ingredient object that was created.
-      + (Error, null) if an error occurs.
-  */
-  ingredients.createIngredient = ({ name, description }, callback) => {
-    database.execute(
-      "INSERT INTO Ingredients(name, description) VALUES(?, ?)",
-      [name, description],
-      (err, rows) => {
-        console.log(err, rows);
-        if (err) {
-          callback(err, null);
-          return;
-        }
-        buildCreateResponse(
-          err,
-          rows,
-          { name, description },
-          Ingredient,
-          callback
-        );
-      }
-    );
-  };
-
-  /**
     getAllIngredients fetches a list of all the Ingredient objects in the system.
     => Receives:
       + callback: function(error, data)
@@ -116,7 +85,6 @@ const Ingredients = (database) => {
       "SELECT * FROM Ingredients WHERE id = ?",
       [ingredientID],
       (err, rows) => {
-        console.log(err, rows);
         if (err) {
           callback(err, null);
           return;

--- a/database/Ingredients.js
+++ b/database/Ingredients.js
@@ -62,16 +62,6 @@ const Ingredients = (database) => {
     => Returns: by calling @callback with:
       + (null, Ingredient) with the Ingredient object that was created.
       + (Error, null) if an error occurs.
-    => Code Example:
-      // Create an Ingredient with @name "foo" and @description "desc".
-      Ingredients.createIngredient({ name: "foo", description: "desc" }, (err, newIngredientObject) => {
-        if (err) {
-          console.log("Failed to create the ingredient. Error:", err);
-          return; // bail out of the handler here, newIngredientObject undefined
-        }
-        // Created the ingredient successfully.
-        console.log("newIngredientObject:", newIngredientObject, "json:", newIngredientObject.toJSON());
-    });
   */
   ingredients.createIngredient = ({ name, description }, callback) => {
     database.execute(
@@ -101,17 +91,6 @@ const Ingredients = (database) => {
     => Returns: by calling @callback with:
       + (null, []Ingredients) the list of Ingredients in the system.
       + (Error, null) if an error occurs.
-    => Code Example:
-      // Get all the Ingredients.
-      Ingredients.getAllIngredients((err, listOfAllIngredients) => {
-        if (err) {
-          console.log("Failed to fetch Ingredients:", err);
-          return;  // bail out of the handler here, listOfAllIngredients undefined
-        }
-        // Got the list of Ingredients.
-        console.log("listOfAllIngredients:", listOfAllIngredients);
-        console.log("listOfAllIngredients as json", listOfAllIngredients.map(ingredient => ingredient.toJSON()));
-      });
   */
  ingredients.getAllIngredients = (callback) => {
   database.execute("SELECT * FROM Ingredients", (err, rows) => {
@@ -132,21 +111,6 @@ const Ingredients = (database) => {
       + (null, Ingredient) with the Ingredient object that was fetched.
       + (Ingrdients.Errors.notFound, null) if the Ingredient could not be found.
       + (Error, null) if another error occurs.
-    => Code Example:
-      // Fetch an Ingredient with ID @ingredientID = 2.
-      Ingredients.getIngredient({ ingredientID: 2 }, (err, ingredientObject) => {
-        if (err) {
-          if (err === Ingredients.Errors.notFound) {
-            console.log("Could not find the ingredient.");
-            return; // bail out of the handler here, ingredientObject undefined
-          }
-          // Another error occurred.
-          console.log("An error occurred with the query. Error:", err);
-          return; // bail out of the handler here, ingredientObject undefined
-        }
-        // Fetched the Ingredient successfully.
-        console.log("ingredientObject:", ingredientObject, "json:", ingredientObject.toJSON());
-      });
   */
   ingredients.getIngredient = ({ ingredientID }, callback) => {
     database.execute(
@@ -176,17 +140,6 @@ const Ingredients = (database) => {
     => Returns: by calling @callback with:
       + (null, []Ingredient) the list of Ingredients in the system with names like the provided @query.
       + (Error, null) if an error occurs.
-    => Code Example:
-      // Search for flour.
-      Ingredients.searchByName({"query": "flour"}, (err, listOfFlourIngredients) => {
-        if (err) {
-          console.log("Failed to fetch Ingredients:", err);
-          return;  // bail out of the handler here, listOfFlourIngredients undefined
-        }
-        // Got the listOfFlourIngredients.
-        console.log("listOfFlourIngredients:", listOfFlourIngredients);
-        console.log("listOfFlourIngredients as json", listOfFlourIngredients.map(ingredient => ingredient.toJSON()));
-      });
   */
   ingredients.searchByName = ({ query }, callback) => {
     database.execute(

--- a/database/RecipeBookRecipes.js
+++ b/database/RecipeBookRecipes.js
@@ -58,16 +58,6 @@ const RecipeBookRecipes = (database) => {
     => Returns: by calling @callback with:
       + (null, []Recipe) a list of Recipe objects on query success. List may be empty.
       + (Error, null) if an error occurs.
-    => Code Example:
-      // Get a list of every Recipe object in RecipeBook with ID @recipeBookID = 1.
-      RecipeBookRecipes.getAllRecipes({recipeBookID: 1}, (err, listOfRecipeObjects) => {
-        if (err) { // Couldn't fetch the recipes.
-          console.log(err);
-          return; // bail out of the handler here, listOfRecipeObjects undefined
-        }
-        // Fetched list of Recipes in RecipeBook.
-        console.log("listOfRecipeObjects:", listOfRecipeObjects);
-      });
   */
   recipeBookRecipes.getAllRecipes = ({ recipeBookID }, callback) => {
     database.execute(

--- a/database/RecipeBookRecipes.js
+++ b/database/RecipeBookRecipes.js
@@ -39,9 +39,8 @@ class RecipeBookRecipe {
 // RecipeBookRecipes defines queries for RecipeBookRecipes. Instantiated with
 // @database, a reference to the mysql connection pool to be used for queries.
 const RecipeBookRecipes = (database) => {
-  // Define any Error messages or Data Validator functions for the module.
+  // Define any Error messages for the module.
   const Errors = {};
-  const Validators = {};
 
   // ======> BEGIN QUERIES <======
 
@@ -78,7 +77,7 @@ const RecipeBookRecipes = (database) => {
     );
   };
 
-  return { ...recipeBookRecipes, Errors, Validators };
+  return { ...recipeBookRecipes, Errors };
 };
 
 module.exports = { RecipeBookRecipes, RecipeBookRecipe };

--- a/database/RecipeBookRecipes.js
+++ b/database/RecipeBookRecipes.js
@@ -72,7 +72,7 @@ const RecipeBookRecipes = (database) => {
           callback(err, null);
           return;
         }
-        buildResponseList(err, rows, Recipe, callback);
+        buildResponseList({ err, rows, callback, entity: Recipe });
       }
     );
   };

--- a/database/RecipeBooks.js
+++ b/database/RecipeBooks.js
@@ -60,14 +60,6 @@ const RecipeBooks = (database) => {
     => Returns: by calling @callback with:
       + (null, insertionInfo) on addition success.
       + (Error, null) if an error occurs.
-    => Code Example:
-      // Add Recipe with ID @recipeID = 2 to RecipeBook with ID @recipeBookId = 1.
-      RecipeBooks.addRecipeByIDToRecipeBookWithID({recipeID: 2, recipeBookID: 1}, (err, insertionInfo) => {
-        if (err) { // addition failed
-          return;  // bail out of the handler here, insertionInfo undefined
-        }
-        // Addition successful. @insertionInfo contains info about the insert if needed.
-      });
   */
   recipeBook.addRecipeByIDToRecipeBookWithID = (
     { recipeID, recipeBookID },
@@ -89,24 +81,6 @@ const RecipeBooks = (database) => {
     => Returns by calling @callback with:
       + (null, []Recipe) array of Recipe objects on query success. Array may be empty.
       + (Error, null) if an error occurs.
-    => Code Example:
-      // Get a list of every Recipe object for RecipeBook with ID @recipeBookID = 1.
-      RecipeBooks.getRecipesForRecipeBookID(
-        { recipeBookID: 1 },
-        (err, listOfRecipeObjects) => {
-          if (err) {
-            if (err === RecipeBooks.Errors.notFound) {
-              // No RecipeBook Recipes found.
-              console.log(err);
-              return; // bail out of the handler here, listOfRecipeObjects undefined
-            }
-            console.log("Some other database error:", err);
-            return; // bail out of the handler here, listOfRecipeObjects undefined
-          }
-          // Fetched list of Recipes successfully.
-          console.log("data", listOfRecipeObjects);
-        }
-      );
   */
   recipeBook.getRecipesForRecipeBookID = ({ recipeBookID }, callback) => {
     database.execute(

--- a/database/RecipeBooks.js
+++ b/database/RecipeBooks.js
@@ -37,10 +37,7 @@ class RecipeBook {
 // a reference to the mysql connection pool to be used for queries.
 const RecipeBooks = (database) => {
   // Define any Error messages for the module.
-  const Errors = {
-    notFound: "No RecipeBook with that ID exists.",
-    recipeBookAlreadyExists: "RecipeBook already exists for user.",
-  };
+  const Errors = {};
 
   // ======> BEGIN QUERIES <======
 
@@ -67,34 +64,6 @@ const RecipeBooks = (database) => {
       "INSERT INTO RecipeBookRecipes(recipe_id, recipebook_id) VALUES(?, ?)",
       [recipeID, recipeBookID],
       (err, data) => callback(err, data)
-    );
-  };
-
-  /**
-    getRecipesForRecipeBookID returns a list of Recipe objects for all the Recipes in
-    the RecipeBook with ID = @recipeBookID. Returns both public and private Recipes.
-    => Receives:
-      + recipeBookID: ID of RecipeBook from which to fetch list of Recipes.
-      + callback: function(error, data)
-    => Returns by calling @callback with:
-      + (null, []Recipe) array of Recipe objects on query success. Array may be empty.
-      + (Error, null) if an error occurs.
-  */
-  recipeBook.getRecipesForRecipeBookID = ({ recipeBookID }, callback) => {
-    database.execute(
-      `
-      SELECT r.* FROM RecipeBookRecipes rbr
-      INNER JOIN Recipes r ON r.id = rbr.recipe_id
-      WHERE recipebook_id = ?
-      `,
-      [recipeBookID],
-      (err, rows) => {
-        if (err) {
-          callback(err, null);
-          return;
-        }
-        buildResponseList(err, rows, Recipe, callback);
-      }
     );
   };
 

--- a/database/RecipeBooks.js
+++ b/database/RecipeBooks.js
@@ -36,13 +36,11 @@ class RecipeBook {
 // RecipeBooks defines queries for RecipeBooks. Instantiated with @database,
 // a reference to the mysql connection pool to be used for queries.
 const RecipeBooks = (database) => {
-  // Define any Error messages or Data Validator functions for the module.
+  // Define any Error messages for the module.
   const Errors = {
     notFound: "No RecipeBook with that ID exists.",
     recipeBookAlreadyExists: "RecipeBook already exists for user.",
   };
-
-  const Validators = {};
 
   // ======> BEGIN QUERIES <======
 
@@ -100,7 +98,7 @@ const RecipeBooks = (database) => {
     );
   };
 
-  return { ...recipeBook, Errors, Validators };
+  return { ...recipeBook, Errors };
 };
 
 module.exports = { RecipeBooks, RecipeBook };

--- a/database/Recipes.js
+++ b/database/Recipes.js
@@ -56,30 +56,6 @@ const Recipes = (database) => {
   const recipes = {};
 
   /*
-    createRecipe creates the Recipe with @name and @isPublic status.
-    => Receives:
-      + name: Name of the Recipe.
-      + isPublic: Whether the Recipe is publicly visible.
-      + callback: function(error, data)
-    => Returns: by calling @callback with:
-      + (null, Recipe) with the Recipe object that was created.
-      + (Error, null) if an error occurs.
-  */
-  recipes.createRecipe = ({ name, isPublic }, callback) => {
-    database.execute(
-      "INSERT INTO Recipes(name, is_public) VALUES(?, ?)",
-      [name, isPublic],
-      (err, rows) => {
-        if (err) {
-          callback(err, null);
-          return;
-        }
-        buildCreateResponse(err, rows, { name, isPublic }, Recipe, callback);
-      }
-    );
-  };
-
-  /*
     createRecipeWithIngredients creates the Recipe with @name and @isPublic status having
     Ingredients with IDs given in @ingredientIDList.
     => Receives:
@@ -151,33 +127,6 @@ const Recipes = (database) => {
   };
 
   /**
-    addIngredientIDToRecipeID adds Ingredient with ID @ingredientID to Recipe with ID @recipeID.
-    => Receives:
-      + ingredientID: ID of the Ingredient to add to Recipe.
-      + recipeID: ID of the Recipe to which to add the Ingredient.
-      + callback: function(error, data)
-    => Returns: by calling @callback with:
-      + (null, null) returns nothing on success
-      + (Error, null) if an error occurs.
-  */
-  recipes.addIngredientIDToRecipeID = (
-    { ingredientID, recipeID },
-    callback
-  ) => {
-    database.execute(
-      "INSERT INTO RecipeIngredients(ingredient_id, recipe_id) VALUES (?, ?)",
-      [ingredientID, recipeID],
-      (err) => {
-        if (err) {
-          callback(err, null);
-          return;
-        }
-        callback(null, null);
-      }
-    );
-  };
-
-  /**
     replaceIngredientForRecipeID replaces Ingredient with ID @toReplaceID with Ingredient with
     ID @replaceWithID for Recipe with ID @recipeID.
     => Receives:
@@ -207,34 +156,6 @@ const Recipes = (database) => {
           return;
         }
         callback(null, null);
-      }
-    );
-  };
-
-  /**
-    getIngredients gets a list of Ingredient objects for Recipe with ID @recipeID
-    => Receives:
-      + recipeID: ID of the Recipe for which to fetch the list of Ingredients.
-      + callback: function(error, data)
-    => Returns: by calling @callback with:
-      + (null, []Ingredients) a list of Ingredient objects in the Recipe.
-      + (Error, null) if an error occurs.
-  */
-  recipes.getIngredients = ({ recipeID }, callback) => {
-    database.execute(
-      `
-      SELECT * FROM Ingredients i
-      INNER JOIN RecipeIngredients ri
-      ON i.id = ri.ingredient_id
-      WHERE ri.recipe_id = ?
-      `,
-      [recipeID],
-      (err, rows) => {
-        if (err) {
-          callback(err, null);
-          return;
-        }
-        buildResponseList(err, rows, Ingredient, callback);
       }
     );
   };

--- a/database/Recipes.js
+++ b/database/Recipes.js
@@ -49,7 +49,6 @@ const Recipes = (database) => {
     recipeBookAlreadyExists: "RecipeBook already exists for user.",
     recipeWithNameAlreadyExists: "Your RecipeBook already has a Recipe with this name.",
   };
-  const Validators = {};
 
   // ======> BEGIN QUERIES <======
 
@@ -444,7 +443,7 @@ const Recipes = (database) => {
     );
   };
 
-  return { ...recipes, Errors, Validators };
+  return { ...recipes, Errors };
 };
 
 module.exports = { Recipes, Recipe };

--- a/database/Recipes.js
+++ b/database/Recipes.js
@@ -47,7 +47,8 @@ const Recipes = (database) => {
   // Define any Error messages or Data Validator functions for the module.
   const Errors = {
     recipeBookAlreadyExists: "RecipeBook already exists for user.",
-    recipeWithNameAlreadyExists: "Your RecipeBook already has a Recipe with this name.",
+    recipeWithNameAlreadyExists:
+      "Your RecipeBook already has a Recipe with this name.",
   };
 
   // ======> BEGIN QUERIES <======
@@ -111,13 +112,13 @@ const Recipes = (database) => {
                   callback(err, null);
                   return;
                 }
-                buildCreateResponse(
+                buildCreateResponse({
                   err,
                   rows,
-                  { name, isPublic, ingredientIDList },
-                  Recipe,
-                  callback
-                );
+                  callback,
+                  entity: Recipe,
+                  creationParams: { name, isPublic, ingredientIDList },
+                });
               }
             );
           }
@@ -174,7 +175,7 @@ const Recipes = (database) => {
         callback(err, null);
         return;
       }
-      buildResponseList(err, rows, Recipe, callback);
+      buildResponseList({ err, rows, callback, entity: Recipe });
     });
   };
 

--- a/database/Recipes.js
+++ b/database/Recipes.js
@@ -65,16 +65,6 @@ const Recipes = (database) => {
     => Returns: by calling @callback with:
       + (null, Recipe) with the Recipe object that was created.
       + (Error, null) if an error occurs.
-    => Code Example:
-      // Create a Recipe with @name "foo" that is public since @isPublic = true.
-      Recipes.createRecipe({ name: "foo", isPublic: true }, (err, newRecipeObject) => {
-        if (err) {
-          console.log("Failed to create the recipe. Error:", err);
-          return; // bail out of the handler here, newRecipeObject undefined
-        }
-        // Created the recipe successfully.
-        console.log("newRecipeObject:", newRecipeObject, "json:", newRecipeObject.toJSON());
-      });
   */
   recipes.createRecipe = ({ name, isPublic }, callback) => {
     database.execute(
@@ -103,16 +93,6 @@ const Recipes = (database) => {
     => Returns: by calling @callback with:
       + (null, Recipe) with the Recipe object that was created.
       + (Error, null) if an error occurs.
-    => Code Example:
-      // Create a Recipe with @name "foo" that is public since @isPublic = true with Ingredients ID = 1 and 2.
-      Recipes.createRecipeWithIngredients({ name: "foo", isPublic: true, ingredientIDList: [1, 2] }, (err, newRecipeObject) => {
-        if (err) {
-          console.log("Failed to create the recipe. Error:", err);
-          return; // bail out of the handler here, newRecipeObject undefined
-        }
-        // Created the recipe successfully.
-        console.log("newRecipeObject:", newRecipeObject, "json:", newRecipeObject.toJSON());
-      });
   */
   recipes.createRecipeWithIngredients = (
     { name, isPublic, ingredientIDList, recipeBookID, username },
@@ -180,16 +160,6 @@ const Recipes = (database) => {
     => Returns: by calling @callback with:
       + (null, null) returns nothing on success
       + (Error, null) if an error occurs.
-    => Code Example:
-      // Create a Recipe with @name "foo" that is public since @isPublic = true.
-      Recipes.createRecipe({ name: "foo", isPublic: true }, (err, newRecipeObject) => {
-        if (err) {
-          console.log("Failed to create the recipe. Error:", err);
-          return; // bail out of the handler here, newRecipeObject undefined
-        }
-        // Created the recipe successfully.
-        console.log("newRecipeObject:", newRecipeObject, "json:", newRecipeObject.toJSON());
-      });
   */
   recipes.addIngredientIDToRecipeID = (
     { ingredientID, recipeID },
@@ -219,16 +189,6 @@ const Recipes = (database) => {
     => Returns: by calling @callback with:
       + (null, null) returns nothing on success
       + (Error, null) if an error occurs.
-    => Code Example:
-      // Replace Ingredient with ID 1 for Ingredient with ID 2 in Recipe with ID 3
-      Recipes.replaceIngredientForRecipeID({ toReplaceID: 1, replaceWithID: 2, recipeID: 3 }, (err, data) => {
-        if (err) {
-          console.log("Failed to replace the ingredient. Error:", err);
-          return;
-        }
-        // Made the replacement successfully. err null, data may be ignored.
-        return;
-      });
   */
   recipes.replaceIngredientForRecipeID = (
     { toReplaceID, replaceWithID, recipeID },
@@ -260,17 +220,6 @@ const Recipes = (database) => {
     => Returns: by calling @callback with:
       + (null, []Ingredients) a list of Ingredient objects in the Recipe.
       + (Error, null) if an error occurs.
-    => Code Example:
-      // Get list of Ingredients for Recipe with ID @recipeID.
-      Recipes.getIngredients({ recipeID: 1 }, (err, listOfIngredients) => {
-        if (err) {
-            console.log("Failed to fetch recipe ingredients:", err);
-            return; // bail out of the handler here, listOfIngredients undefined
-        }
-        // Got the Ingredients list.
-        console.log("listOfIngredients:", listOfIngredients);
-        console.log("listOfIngredients as json", listOfIngredients.map(ingredient => ingredient.toJSON()));
-      });
   */
   recipes.getIngredients = ({ recipeID }, callback) => {
     database.execute(
@@ -298,17 +247,6 @@ const Recipes = (database) => {
     => Returns: by calling @callback with:
       + (null, []Recipes) the list of Recipes in the system.
       + (Error, null) if an error occurs.
-    => Code Example:
-      // Get all the Recipes.
-      Recipes.getAllRecipes((err, listOfAllRecipes) => {
-        if (err) {
-          console.log("Failed to fetch Recipes:", err);
-          return;  // bail out of the handler here, listOfAllRecipes undefined
-        }
-        // Got the list of Rrecipes.
-        console.log("listOfAllRecipes:", listOfAllRecipes);
-        console.log("listOfAllRecipes as json", listOfAllRecipes.map(recipe => recipe.toJSON()));
-      });
   */
   recipes.getAllRecipes = (callback) => {
     database.execute("SELECT * FROM Recipes", (err, rows) => {
@@ -344,16 +282,6 @@ const Recipes = (database) => {
         replacements that we suggest. All data are returned as json for display to the user, rather
         than as objects for manipulation.
       + (Error, null) if an error occurs.
-    => Code Example:
-      // Search for Cupcakes.
-      Recipes.searchByName({"query": "Cupcakes"}, (err, listOfAllCupcakeRecipes) => {
-        if (err) {
-          console.log("Failed to fetch Recipes:", err);
-          return;  // bail out of the handler here, listOfAllCupcakeRecipes undefined
-        }
-        // Got the listOfAllCupcakeRecipes.
-        console.log("listOfAllCupcakeRecipes:", listOfAllCupcakeRecipes, "json string", JSON.stringify(listOfAllCupcakeRecipes));
-      });
   */
   recipes.searchByName = ({ query }, callback) => {
     database.execute(
@@ -421,21 +349,6 @@ const Recipes = (database) => {
         replacements that we suggest. All data are returned as json for display to the user, rather
         than as objects for manipulation.
       + (Error, null) if an error occurs.
-    => Code Example:
-      // Search for Cupcakes.
-      Recipes.getByIDWithIngredientsAndReplacements({"recipeID": 1}, (err, recipeWithIngredientsAndReplacements) => {
-        if (err) {
-          console.log("Failed to fetch Recipe:", err);
-          return;  // bail out of the handler here, recipeWithIngredientsAndReplacements undefined
-        }
-        // Got the recipeWithIngredientsAndReplacements.
-        console.log(
-          "recipeWithIngredientsAndReplacements:",
-          recipeWithIngredientsAndReplacements,
-          "json string",
-          JSON.stringify(recipeWithIngredientsAndReplacements)
-        );
-      });
   */
   recipes.getByIDWithIngredientsAndReplacements = ({ recipeID }, callback) => {
     database.execute(
@@ -489,15 +402,6 @@ const Recipes = (database) => {
     => Returns: by calling @callback with:
       + (null, recipeID) the ID of the recipe that was cloned.
       + (Error, null) if an error occurs.
-    => Code Example:
-      // Clone recipeID 2 and assign owner as User with username "testuser123"
-      Recipes.clone({ "recipeID": 2, "username": "testuser123" }, (err, clonedRecipeID) => {
-        if (err) {
-          console.log("Failed to clone Recipe:", err);
-          return;  // bail out of the handler here, clonedRecipeID undefined
-        }
-        console.log("clonedRecipeID:", clonedRecipeID);
-      });
     => Attribution: First Insert Recipe name select trick: https://stackoverflow.com/a/43610081
   */
   recipes.clone = ({ recipeID, username }, callback) => {

--- a/database/Users.js
+++ b/database/Users.js
@@ -44,20 +44,11 @@ class User {
 // Users defines queries for Users. Instantiated with @database, a
 // reference to the mysql connection pool to be used for queries.
 const Users = (database) => {
-  // Define any Error messages or Data Validator functions for the module.
+  // Define any Error messages for the module.
   const Errors = {
     notFound: "No user with that Username exists.",
     usernameInUse: "Username is already in use.",
     invalidUsernameOrPassword: "Invalid Username or Password.",
-  };
-
-  // TODO update these to do REAL validation that we want for our usernames and passwords.
-  const Validators = {
-    // returns True if username is valid, False if not.
-    // Note: "valid" does not mean "in use". See: Users.Errors.usernameInUse.
-    usernameIsValid: (username) => username.length > 2,
-    // returns True if password is valid, False if not.
-    passwordIsValid: (password) => password.length > 2,
   };
 
   // ======> BEGIN QUERIES <======
@@ -180,7 +171,7 @@ const Users = (database) => {
     );
   };
 
-  return { ...user, Errors, Validators };
+  return { ...user, Errors };
 };
 
 module.exports = { Users, User };

--- a/database/Users.js
+++ b/database/Users.js
@@ -107,13 +107,17 @@ const Users = (database) => {
                   callback(err, null);
                   return;
                 }
-                buildCreateResponse(
+                buildCreateResponse({
                   err,
-                  userRows,
-                  { username, password, recipeBookID: recipeBook.insertId },
-                  User,
-                  callback
-                );
+                  rows: userRows,
+                  callback,
+                  entity: User,
+                  creationParams: {
+                    username,
+                    password,
+                    recipeBookID: recipeBook.insertId,
+                  },
+                });
               }
             );
           }
@@ -139,10 +143,15 @@ const Users = (database) => {
       [username, password],
       (err, rows) => {
         if (!rows || rows.length !== 1) {
-          buildResponse(Errors.invalidUsernameOrPassword, rows, User, callback);
+          buildResponse({
+            err: Errors.invalidUsernameOrPassword,
+            rows,
+            callback,
+            entity: User,
+          });
           return;
         }
-        buildResponse(err, rows, User, callback);
+        buildResponse({ err, rows, callback, entity: User });
       }
     );
   };
@@ -163,10 +172,10 @@ const Users = (database) => {
       [username],
       (err, rows) => {
         if (!rows || rows.length === 0) {
-          buildResponse(Errors.notFound, rows, User, callback);
+          buildResponse({ err: Errors.notFound, rows, callback, entity: User });
           return;
         }
-        buildResponse(err, rows, User, callback);
+        buildResponse({ err, rows, callback, entity: User });
       }
     );
   };

--- a/database/Users.js
+++ b/database/Users.js
@@ -80,20 +80,6 @@ const Users = (database) => {
       TODO: of course for a production system, you should hash the password and
       store the hash, not the password in plaintext. For dev and testing, this
       has been omitted but is crucial if you're storing real user data.
-    => Code Example:
-      Users.createUserWithUsernameAndPassword({"username": "foo", "password": "bar"}, (err, newUserObject) => {
-        if (err) {
-          if (err === Users.Errors.usernameInUse) {
-            // Inform the user they must pick a different username. newUserObject is null.
-            console.log(err);
-            return; // bail out of the handler here, newUserObject undefined
-          }
-          // Another error occurred.
-          console.log(err); // bail out of the handler here, newUserObject undefined
-        }
-        // User created successfully.
-        console.log("newUserObject:", newUserObject, "user JSON:", newUserObject.toJSON());
-      });
   */
   user.createUserWithUsernameAndPassword = (
     { username, password },
@@ -155,21 +141,6 @@ const Users = (database) => {
       + (null, Instance of the User object) if the user successfully authenticated.
       + (Users.Errors.invalidUsernameOrPassword, null) if the @username or @password are invalid.
       + (Error, null) if another error occurs.
-    => Code Example:
-      // Attempt to log in user with @username "foo" and @password "bar"
-      Users.logInWithUsernameAndPassword(
-        { username: "foo", password: "bar" },
-        (err, userObject) => {
-          if (err === Users.Errors.invalidUsernameOrPassword) {
-            // Let the user know they entered the wrong username or password...
-            console.log(err);
-            return; // bail out of the handler here, userObject undefined
-          }
-          // Now we have the User object. Probably set up a session here on the server
-          // and give the user a cookie to send back and send on future requests.
-          console.log("User object:", userObject, "user JSON": userObject.toJSON());
-        }
-      );
   */
   user.logInWithUsernameAndPassword = ({ username, password }, callback) => {
     database.execute(
@@ -194,16 +165,6 @@ const Users = (database) => {
       + (null, Instance of the User object) if such a User exists
       + (Users.Errors.notFound, null) if no such User with @username can be found.
       + (Error, null) if another error occurs.
-    => Code Example:
-      // Fetch a User by username foo, if user exists.
-      Users.getUserByUsername({ username: "foo" }, (err, userObject) => {
-        if (err) {
-          console.log("Couldn't fetch user. Error:", err);
-          return; // bail out of the handler here, userObject undefined
-        }
-        // Do something with the User object.
-        console.log("userObject:", userObject, "json:", userObject.toJSON());
-      });
   */
   user.getUserByUsername = ({ username }, callback) => {
     database.execute(

--- a/database/utils.js
+++ b/database/utils.js
@@ -6,7 +6,7 @@
 // @callback function with the appropriate (err, data) response. Used for initial
 // entity creation: adds the insertId to the object. If data is present, it calls the
 // @callback with an instance of class of type @entity instantiated with data from @rows.
-const buildCreateResponse = (err, rows, creationParams, entity, callback) => {
+const buildCreateResponse = ({err, rows, creationParams, entity, callback} = {}) => {
   if (!nullOrUndefined(err)) {
     callback(err, null);
     return;
@@ -22,7 +22,7 @@ const buildCreateResponse = (err, rows, creationParams, entity, callback) => {
 // @callback function with the appropriate (err, data) response. If data is present,
 // it calls the @callback with an instance of class of type @entity instantiated
 // with data from @rows.
-const buildResponse = (err, rows, entity, callback) => {
+const buildResponse = ({err, rows, entity, callback} = {}) => {
   if (!nullOrUndefined(err)) {
     callback(err, null);
     return;
@@ -38,7 +38,7 @@ const buildResponse = (err, rows, entity, callback) => {
 // @callback function with the appropriate (err, data) response. If data is present, it
 // calls the @callback with a list of instances of class of type @entity instantiated
 // with data from @rows.
-const buildResponseList = (err, rows, entity, callback) => {
+const buildResponseList = ({err, rows, entity, callback} = {}) => {
   if (!nullOrUndefined(err)) {
     callback(err, null);
     return;


### PR DESCRIPTION
This PR fixes 3 code smells with the Database code I added in previous sprints.

1. Dispensables -> Comments (https://refactoring.guru/smells/comments) Each db function had complete example code which was just bloat -- the functions all have the same interface, named parameters, and a description of what it does, receives, and returns. There's also examples in the Application Code already for reference.

2. Dead Code (https://refactoring.guru/smells/dead-code) A lot of the db functions were unused since we ended up needing something slightly different. I removed all unused functions and unused elements of the code (like Errors we never send, or Validators we never use) so that you'll only see things in there that's actually useful and being used in the application code.

3. Long Parameter List (https://refactoring.guru/smells/long-parameter-list) Many of the db functions had helper functions to assemble a client response with the data / errors. These took 4 - 5 params where order mattered. I refactored to make these named params in a single parameter object so there's no longer an order dependence.

I tested these changes and there's zero functional impact on any of the application flows.