### PR TITLE
Fix single ingredient bug

### DIFF
--- a/routes/buildRecipeRouter.js
+++ b/routes/buildRecipeRouter.js
@@ -34,7 +34,11 @@ buildRecipeRouter.route('/')
     }
     let ingredients = req.body.ingredients;
     if (!Array.isArray(ingredients)) {
-        ingredients = Array.from(ingredients);
+        // If recipe has just one ingredient, req.body.ingredients will be a
+        // single ID, like "14" instead of an array. createRecipeWithIngredients
+        // requires an array of ingredients, so make an array with a single
+        // ingredient ID in this case.
+        ingredients = [ingredients];
     }
     console.log("Building recipe with name, ingredients, recipeBookID:", name, ingredients, res.locals.recipeBookID);
     Models.Recipes.createRecipeWithIngredients(


### PR DESCRIPTION
Previously when a recipe was made with a single ingredient, we split the ID of the single ingredient into an array, so ingredient ID "22" would become ["2", "2"]. When a recipe was made with multiple ingredients, the ingredients list was correct, e.g., IDs "22" and "23" would be given as ["22", "23"]. This PR updates to not split a single ingredient ID into an array (so "22" won't become ["2", "2"] but rather ["22"]).