### PR TITLE
404 on RecipeID not found, get uid from session, spacing on 404/500 pgs

### DIFF
--- a/app.js
+++ b/app.js
@@ -158,6 +158,7 @@ app.post('/register', async (req, res) => {
 							req.session.user_id = username;
 							res.locals.user_id = username;
 							req.session.recipeBookID = user.recipeBookID;
+							req.session.user_id_numeric = user.id;
 							res.render('index');
 						} else {
 							context.registerError = 'Username taken';

--- a/routes/recipesRouter.js
+++ b/routes/recipesRouter.js
@@ -56,8 +56,12 @@ recipesRouter.route("/:recipeID").get((req, res, next) => {
         return next(err); // bail out of the handler here, recipeWithReplacements undefined
       }
 
+      if (!recipeWithReplacements) {
+        res.status(404);
+        return res.render("404");
+      }
       // Make sure if the recipe's private that there's a logged in user and they are the owner.
-      const sessionNumericUserId = res.locals.user_id_numeric;
+      const sessionNumericUserId = req.session.user_id_numeric;
       if (!recipeWithReplacements.recipe.isPublic && recipeWithReplacements.recipe.ownerId !== sessionNumericUserId) {
         // the recipe is private and the user is not the owner.
         return res.redirect('/login');

--- a/views/404.handlebars
+++ b/views/404.handlebars
@@ -1,1 +1,3 @@
-<h1>Error 404 - Page Is Nowhere to be Found</h1>
+<div style="margin: 64px auto; text-align:center;">
+    <h1>Error 404 - Page Is Nowhere to be Found</h1>
+</div>

--- a/views/500.handlebars
+++ b/views/500.handlebars
@@ -1,1 +1,3 @@
-<h1>Error 500 - Something Has Gone Terribly Wrong</h1>
+<div style="margin: 64px auto; text-align:center;">
+    <h1>Error 500 - Something Has Gone Terribly Wrong</h1>
+</div>


### PR DESCRIPTION
This fixes a bug where the numeric user id was not set on the session immediately after creation, meaning you couldn't view your own private recipes during that session. Also centers the 404 and 500 text to have appearance of other pages and 404s on unknown RecipeID instead of erroring out.