### PR TITLE
Fix bugs, info popover in recipe builder

### DIFF
--- a/database/database-definitions.sql
+++ b/database/database-definitions.sql
@@ -520,7 +520,7 @@ INSERT INTO IngredientReplacements(ingredient_id_replaces, ingredient_id_replace
   (SELECT id FROM Ingredients WHERE name = "Almonds"),
   (SELECT id FROM Ingredients WHERE name = "Hazlenuts"),
   "require less water to produce than other nuts like Almonds or Cashews.",
-  "https://healabel.com/a-ingredients/almonds https://healabel.com/h-ingredients/hazelnuts"
+  "https://healabel.com/h-ingredients/hazelnuts"
 ),
 (
   (SELECT id FROM Ingredients WHERE name = "Almonds"),

--- a/public/js/buildRecipe.js
+++ b/public/js/buildRecipe.js
@@ -15,7 +15,7 @@ function addIngredients() {
     ingredientSelect.className = 'added ' + className
     let htmlContent = document.getElementById('ingredientSelect').innerHTML
     htmlContent += '<button onclick="removeIngredient(\'' + className + '\');">Remove Ingredient</button>'
-    htmlContent += '<br><a href="/ingredientEthics/2"id ="recipe_link'+ ingredientCount+ '">Ingredient Detail</a>'
+    htmlContent += '<br><a href="/ingredientEthics/2" class="ingredient-detail-popup" id ="recipe_link'+ ingredientCount+ '">Ingredient Detail</a>'
     
     ingredientSelect.innerHTML = htmlContent
     ingredientFields.appendChild(ingredientSelect)
@@ -54,3 +54,90 @@ function startOver() {
 // wait for page content to load
 document.addEventListener("DOMContentLoaded", buttonFunctions)
 
+
+// getToolTipData fetches JSON data for the ingredient at link and calls callback.
+function getToolTipData(link, callback) {
+    const fetchOptions = {
+      method: "GET",
+      headers: {
+        "Accept": "application/json",
+        "Content-Type": "application/json",
+      },
+    };
+    fetch(link, fetchOptions)
+        .then(data => data.json())
+        .then(jsonData => callback(null, jsonData))
+        .catch(err => callback(err, null));
+}
+
+getVal(1)
+function getVal(num)
+{
+    var selectedVal = document.getElementById("ingredients"+num).value;
+    var link = document.getElementById("recipe_link"+num);
+    var final = /ingredientEthics/ + selectedVal
+
+    // Attribution: Used bootstrap documentation to set up popover code.
+    // https://getbootstrap.com/docs/4.0/components/popovers/
+    link.setAttribute("href", final);
+    link.setAttribute("tabindex", 0);
+    link.setAttribute("data-html", true);
+    link.setAttribute("data-toggle", "popover");
+    link.setAttribute("data-trigger", "focus");
+    link.setAttribute("data-placement", "right");
+    link.classList.add("ingredient-detail-popup");
+
+    // fetch pop-over tooltip data to populate the tip for this particular link.
+    getToolTipData(final, function(err, data) {
+        if (err) {
+            // if there's an error loading the tooltip data, then
+            // fallback to default link behavior.
+            link.removeEventListener("click", function(event) {
+                event.preventDefault();
+            });
+            return;
+        }
+        // no error loading tool tip data, so show the pop-over
+        // tool tip instead of linking to the ingredients page.
+        link.addEventListener("click", function(event) {
+            event.preventDefault();
+        });
+        link.setAttribute("data-original-title", `${data.ingredient.name}<br />${data.ingredient.description}`);
+        const noProblems = `This ingredient has no ethical issues. Great choice!`;
+        const hasProblems = `This ingredient has some ethical downsides because of the amount of water required to produce it. You could consider replacing it with one of the following options.`;
+
+        // Set the popover data depending on if there are replacements or not.
+        if (!data.ingredientReplacements.length) {
+            link.setAttribute("data-content", noProblems);
+                $('[data-toggle="popover"]').popover({ "html": true });
+            link.innerHTML = "Ethically OK <i class='material-icons'>done</i>";
+        } else {
+            link.innerHTML = "See Ethical Alternatives <i class='material-icons'>warning</i>";
+            // build an LI tag for all the ingredientReplacements
+            const ingredientLI = data.ingredientReplacements.map(r =>
+                `<li><strong><a href="/ingredientEthics/${r.ingredientIDReplacement}?backAction=close" target="_blank">${r.name}</strong></a> ${r.replacementReason} <a href="${r.replacementReasonSource}" target="_blank">[source]</a></li>`).join("");
+            link.setAttribute("data-content", `${hasProblems}<br /><br /><ul>${ingredientLI}</ul>`);
+            $('[data-toggle="popover"]').popover({ "html": true });
+        }
+    });
+}
+
+$(function () {
+    // Attribution: Used bootstrap documentation to set up popover code.
+    // https://getbootstrap.com/docs/4.0/components/popovers/
+    $('[data-toggle="popover"]').popover();
+    $('.popover-dismiss').popover({ trigger: "focus" });
+    const $showProblemsButton = $("button#toggle-show-problems");
+    const showMeProblems = "Show Me Ethical Problems";
+    const hideProblems = "Hide Ethical Problems";
+    $("button#toggle-show-problems").click(function() {
+        $("html").toggleClass("ingredient-detail-popup-hidden");
+        const currentText = $showProblemsButton.text();
+        if (currentText === showMeProblems) {
+            $showProblemsButton.text(hideProblems);
+        } else {
+            $showProblemsButton.text(showMeProblems);
+        }
+    });
+    $("html").addClass("ingredient-detail-popup-hidden");
+});

--- a/routes/ethicalRouter.js
+++ b/routes/ethicalRouter.js
@@ -15,7 +15,6 @@ context.ingredientReplacements
 ethicalRouter.route('/:ingredientId')
 .get((req, res, next) => {
   context = {};
-
   // Get ingredient info from DB
   Models.Ingredients.getIngredient({ ingredientID: req.params.ingredientId }, (err, ingredientObject) => {
     if (err) {
@@ -38,7 +37,36 @@ ethicalRouter.route('/:ingredientId')
         }
         context.originalIngredient = ingredientObject;
         context.ingredientReplacements = listOfIngredientObjects;
-        res.render('ingredientEthics', context);
+        if (req.query.backAction === "close") {
+          context.backActionClose = true;
+        }
+
+        // If client sets Accept header to application/json, return a JSON representation
+        // of the page rather than rendering the template itself. This way a client can
+        // consume the data to display on the same page, e.g., as a pop-over tooltip.
+        if (req.headers.accept && req.headers.accept === "application/json") {
+          return res.json(context);
+        }
+
+        // If the user isn't viewing this in the context of a recipe
+        // then don't show the replacements as a form -- set noEdit.
+        if (!req.query.recipeID) {
+          context.noEdit = true;
+          return res.render('ingredientEthics', context);
+        }
+
+        // Fetch the recipe to see if the user owns it -- if so, show them
+        // the editing form. if not, do not give user the ability to edit.
+        context.noEdit = false;
+        Models.Recipes.getByIDWithIngredientsAndReplacements({"recipeID": req.query.recipeID}, function(err, data) {
+          if (err) {
+            return res.status(500).render("500");
+          }
+          if (data.recipe.ownerId === null || data.recipe.ownerId !== req.session.user_id_numeric) {
+            context.noEdit = true;
+          }
+          res.render('ingredientEthics', context);
+        });
       }
     );
   });

--- a/views/book.handlebars
+++ b/views/book.handlebars
@@ -48,7 +48,7 @@
     <br />
     
     <!-- will link to page where user can create new recipe -->
-    <button onclick="window.location.href='build'" class="createNewRecipe">
+    <button onclick="window.location.href='/build'" class="createNewRecipe">
         Create New Recipe
     </button>
 </div>

--- a/views/buildRecipe.handlebars
+++ b/views/buildRecipe.handlebars
@@ -1,4 +1,26 @@
-<script src='js/buildRecipe.js'></script>
+<style>
+    i {
+        font-family: "Material Icons";
+        font-size: 24px;
+        text-decoration: none;
+    }
+    a.ingredient-detail-popup {
+        display: flex;
+        justify-content: flex-start;
+        align-items: center;
+        width: 32%;
+    }
+    a i.material-icons {
+        text-decoration: none;
+    }
+    div.added {
+        margin: 16px 0px;
+    }
+    html.ingredient-detail-popup-hidden .ingredient-detail-popup {
+        display: none;
+    }
+</style>
+
 <div class="card " class="border border-primary" style="width: 50rem;margin:0 auto;">
     <div class="card-body">
 
@@ -24,6 +46,11 @@
                     <li>Review your recipe</li>
                     <li>Submit!</li>
                 </ol>
+
+                <p>
+                    We can show ethical problems with the ingredients as you add them.
+                    <button id="toggle-show-problems">Show Me Ethical Problems</button>
+                </p>
 
                 {{#if user_id}}
                 <form action="/build" method="POST">
@@ -86,18 +113,6 @@
 
     </div>
 </div>
-<div id="first">
-<script>
-getVal(1)
-function getVal(num)
-{
-var selectedVal = document.getElementById("ingredients"+num).value;
-var link = document.getElementById("recipe_link"+num);
-var final = /ingredientEthics/ + selectedVal
-   link.setAttribute("href", final);
-console.log(selectedVal);
-}
-</script>
-</div>
+<div id="first"></div>
 
-
+<script src='/js/buildRecipe.js?v=1606429235'></script>

--- a/views/ingredientEthics.handlebars
+++ b/views/ingredientEthics.handlebars
@@ -3,13 +3,17 @@
 </head>
 <div>
     <p>
+        {{#if backActionClose}}
+        <button onclick="window.close()" style="height:4em;width:16em;margin-left:4em;font-size:medium">
+            <-- Back to Recipe
+        </button>
+        {{else}}
         <button onclick="history.back()" style="height:4em;width:16em;margin-left:4em;font-size:medium">
             <-- Back to Recipe
         </button>
+        {{/if}}
     </p>
 
-    
-    
     <div class="ingredientCard">
         <div style="padding: 4em">
             <h1 id="recipeBookHomeTitle">{{ingredient.name}}</h1>
@@ -22,15 +26,25 @@
                 You could consider replacing it with one of the following options.</p>
                 <br/>
             <h3><b>Replacement Suggestions</b></h3>
+            {{#unless noEdit}}
             <form id="submitIngredientReplacement">
-
+            {{/unless}}
             {{#each ingredientReplacements}}
             <div class="ingredientReplacementSuggestion">
-                <input type="radio" id="replacement_{{@index}}" name="replaceWithIDName" value="{{ingredientIDReplacement}}_{{name}}">
-                <a href="/ingredientEthics/{{ingredientIDReplacement}}"><strong>{{name}}</strong></a>
-                <label for="replacement_{{@index}}">{{replacementReason}} <a href="{{replacementReasonSource}}" target="_blank">[source]</a></label>
+                {{#if ../noEdit}}
+                    <li>
+                        <a href="/ingredientEthics/{{ingredientIDReplacement}}"><strong>{{name}}</strong></a> {{replacementReason}} <a href="{{replacementReasonSource}}" target="_blank">[source]</a>
+                {{else}}
+                    <input type="radio" id="replacement_{{@index}}" name="replaceWithIDName" value="{{ingredientIDReplacement}}_{{name}}">
+                    <a href="/ingredientEthics/{{ingredientIDReplacement}}"><strong>{{name}}</strong></a>
+                    <label for="replacement_{{@index}}">{{replacementReason}} <a href="{{replacementReasonSource}}" target="_blank">[source]</a></label>
+                {{/if}}
+                {{#if ../noEdit}}
+                    </li>
+                {{/if}}
             </div>
             {{/each}}
+            {{#unless noEdit}}
                 <input type="hidden" name="originalIngredientID" value="{{originalIngredient.id}}">
                 <input type="hidden" name="originalIngredientName" value="{{originalIngredient.name}}">
                 <input type="radio" id="no_change" name="replaceWithIDName" value="null" checked>
@@ -38,6 +52,7 @@
 
                 <input type="submit" value="Replace Ingredient">
             </form>
+            {{/unless}}
             {{else}}
             <p>We did not identify any ethical issues with this ingredient. It requires relatively little
                 water to produce and is a great ethical choice from our perspective.

--- a/views/layouts/main.handlebars
+++ b/views/layouts/main.handlebars
@@ -9,6 +9,11 @@
     <!--Required for Bootstrap -->
     <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.3.1/css/bootstrap.min.css"
         integrity="sha384-ggOyR0iXCbMQv3Xipma34MD+dH/1fQ784/j6cY/iJTQUOhcWr7x9JvoRxT2MZw1T" crossorigin="anonymous">
+    <script src="https://code.jquery.com/jquery-3.2.1.slim.min.js" integrity="sha384-KJ3o2DKtIkvYIK3UENzmM7KCkRr/rE9/Qpg6aAZGJwFDMVNA/GpGFF93hXpG5KkN" crossorigin="anonymous"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/popper.js/1.12.9/umd/popper.min.js" integrity="sha384-ApNbgh9B+Y1QKtv3Rn7W3mgPxhU9K/ScQsAP7hUibX39j7fakFPskvXusvfa0b4Q" crossorigin="anonymous"></script>
+    <script src="https://maxcdn.bootstrapcdn.com/bootstrap/4.0.0/js/bootstrap.min.js" integrity="sha384-JZR6Spejh4U02d8jOt6vLEHfe/JQGiRRSQQxSfFWpi1MquVdAyjUar5+76PVCmYl" crossorigin="anonymous"></script>
+    <link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet">
+
     {{!-- can add more CSS if needed --}}
     <link rel='stylesheet' href='/css/background.css'>
 </head>


### PR DESCRIPTION
This PR fixes three issues.

Closes https://github.com/t-fa/EthicalEating/issues/92 -- by showing an info popover in the Recipe Builder view, users can simply select one of the suggested replacements on the same page, rather than having to switch pages. Users can opt to turn off the recipe problems view if they wish so they have that choice.

Closes https://github.com/t-fa/EthicalEating/issues/93 -- users can no longer edit a public recipe through the Ingredients View if they don't own it -- replacements are shown, but they're not anymore visible in a form that allows editing the recipe.

Closes https://github.com/t-fa/EthicalEating/issues/94 -- updated path to recipe builder page so it will work even when the toggle button has been clicked